### PR TITLE
Hardening iteration 4: DoS caps, mermaid UX, CI supply-chain, network defense

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
   directory: "/web"
   schedule:
     interval: "monthly"
+- package-ecosystem: "github-actions" # keeps the SHA-pinned action versions current
+  directory: "/"
+  schedule:
+    interval: "monthly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,23 +6,26 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: '22'
         cache: 'npm'
         cache-dependency-path: web/package-lock.json
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: 'go.mod'
         check-latest: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,10 +19,10 @@ jobs:
       packages: write
       id-token: write # keyless cosign signing via OIDC
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -30,14 +30,14 @@ jobs:
 
       - name: Set up QEMU
         # Needed to emulate the arm64 runtime stage's RUN (adduser) on the amd64 runner.
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Extract image metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           # metadata-action lowercases the image name, so the mixed-case repo
           # (odinnordico/PrivUtil) becomes ghcr.io/odinnordico/privutil.
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,22 +6,25 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: 'go.mod'
           cache: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,18 +29,18 @@ jobs:
           - goarch: arm64
             goos: windows
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: '22'
         cache: 'npm'
         cache-dependency-path: web/package-lock.json
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: 'go.mod'
         check-latest: true
@@ -64,7 +64,7 @@ jobs:
         fi
 
     - name: Upload to Release
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: ${{ env.ARTIFACT_PATH }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,11 +19,11 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,23 +6,26 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: '22'
         cache: 'npm'
         cache-dependency-path: web/package-lock.json
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: 'go.mod'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS build
 
 RUN apk add --no-cache make g++ nodejs npm
 
@@ -27,7 +27,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-go BUILD_VERSION=${VERSION}
 
-FROM alpine:3.23
+FROM alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
 RUN addgroup -S privutil && adduser -S privutil -G privutil
 COPY --from=build /PrivUtil/privutil /bin/privutil
 USER privutil

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ FROM alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc
 RUN addgroup -S privutil && adduser -S privutil -G privutil
 COPY --from=build /PrivUtil/privutil /bin/privutil
 USER privutil
+# The binary now defaults to loopback; containers must bind all interfaces to be
+# reachable via port mapping. Access is still gated by the Host-header allowlist
+# (localhost/127.0.0.1 by default; set ALLOWED_HOSTS for LAN/custom domains).
+ENV HOST=0.0.0.0
 # Documents the default listen port (override with -port/PORT).
 EXPOSE 8090
 # Probe the SPA root so orchestrators can detect an unhealthy container. Shell

--- a/cmd/privutil/main.go
+++ b/cmd/privutil/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	connect "connectrpc.com/connect"
 
@@ -29,7 +30,8 @@ const maxRPCRequestBytes = 32 << 20
 func main() {
 	// Define CLI flags
 	port := flag.String("port", getEnvOrDefault("PORT", "8090"), "Port to listen on")
-	host := flag.String("host", getEnvOrDefault("HOST", ""), "Host to bind to (empty = all interfaces)")
+	host := flag.String("host", getEnvOrDefault("HOST", "127.0.0.1"), "Host to bind to (default: loopback; use 0.0.0.0 for all interfaces)")
+	allowedHosts := flag.String("allowed-hosts", getEnvOrDefault("ALLOWED_HOSTS", ""), "Comma-separated extra Host header values to accept (for LAN/custom-domain access)")
 	logLevel := flag.String("log-level", getEnvOrDefault("LOG_LEVEL", "info"), "Log level: debug, info (debug adds file/line to log output)")
 	version := flag.Bool("version", false, "Print version and exit")
 
@@ -39,9 +41,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nEnvironment Variables:\n")
-		fmt.Fprintf(os.Stderr, "  PORT       Port to listen on (default: 8090)\n")
-		fmt.Fprintf(os.Stderr, "  HOST       Host to bind to (default: all interfaces)\n")
-		fmt.Fprintf(os.Stderr, "  LOG_LEVEL  Log level (default: info)\n")
+		fmt.Fprintf(os.Stderr, "  PORT           Port to listen on (default: 8090)\n")
+		fmt.Fprintf(os.Stderr, "  HOST           Host to bind to (default: 127.0.0.1; use 0.0.0.0 for all interfaces)\n")
+		fmt.Fprintf(os.Stderr, "  ALLOWED_HOSTS  Extra Host header values to accept, comma-separated\n")
+		fmt.Fprintf(os.Stderr, "  LOG_LEVEL      Log level (default: info)\n")
 	}
 
 	flag.Parse()
@@ -73,12 +76,29 @@ func main() {
 
 	// Create and start HTTP server
 	addr := *host + ":" + *port
-	srv := server.New(addr, rpcPath, rpcHandler)
+	srv := server.New(addr, rpcPath, rpcHandler, buildAllowedHosts(*host, *allowedHosts))
 
 	log.Printf("Starting PrivUtil on %s...", addr)
 	if err := srv.Start(); err != nil {
 		log.Fatalf("Server failed to start: %v", err)
 	}
+}
+
+// buildAllowedHosts returns the Host-header allowlist: the loopback names
+// always, the concrete bind host when it isn't a wildcard, plus any extra hosts
+// (comma-separated). This is what lets the container (HOST=0.0.0.0) still be
+// reached at localhost while blocking DNS-rebinding from other hostnames.
+func buildAllowedHosts(bindHost, extra string) []string {
+	hosts := []string{"localhost", "127.0.0.1", "::1"}
+	if bindHost != "" && bindHost != "0.0.0.0" && bindHost != "::" {
+		hosts = append(hosts, bindHost)
+	}
+	for _, h := range strings.Split(extra, ",") {
+		if h = strings.TrimSpace(h); h != "" {
+			hosts = append(hosts, h)
+		}
+	}
+	return hosts
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/internal/api/data_handlers.go
+++ b/internal/api/data_handlers.go
@@ -521,7 +521,8 @@ func toPascalCase(s string) string {
 	words := strings.Fields(s)
 	for i, w := range words {
 		if len(w) > 0 {
-			words[i] = strings.ToUpper(w[:1]) + w[1:]
+			rw := []rune(w)
+			words[i] = strings.ToUpper(string(rw[:1])) + string(rw[1:])
 		}
 	}
 	return strings.Join(words, "")

--- a/internal/api/datetime_handlers.go
+++ b/internal/api/datetime_handlers.go
@@ -233,6 +233,9 @@ func (s *Server) LeapYear(_ context.Context, req *pb.LeapYearRequest) (*pb.LeapY
 				return &pb.LeapYearResponse{Error: fmt.Sprintf("invalid year %q", part)}, nil
 			}
 			years = append(years, y)
+			if len(years) > 400 {
+				return &pb.LeapYearResponse{Error: "too many years — max 400"}, nil
+			}
 		}
 	}
 

--- a/internal/api/encoding_handlers.go
+++ b/internal/api/encoding_handlers.go
@@ -143,6 +143,13 @@ func (s *Server) BaseConvert(ctx context.Context, req *pb.BaseConvertRequest) (*
 	if input == "" {
 		return &pb.BaseConvertResponse{Error: "Input cannot be empty"}, nil
 	}
+	// Bound the input: big.Int parsing and the base64 DivMod loop are
+	// superlinear (the loop is O(n²)), so a large body would pin a core.
+	// 10k digits is already a ~33k-bit number, far beyond any real use.
+	const maxBaseConvertLen = 10_000
+	if len(input) > maxBaseConvertLen {
+		return &pb.BaseConvertResponse{Error: fmt.Sprintf("input too long (limit %d characters)", maxBaseConvertLen)}, nil
+	}
 
 	// Strip prefixes
 	inputLower := strings.ToLower(input)

--- a/internal/api/hardening_test.go
+++ b/internal/api/hardening_test.go
@@ -122,6 +122,54 @@ func TestOtpValidate8Digit(t *testing.T) {
 	}
 }
 
+// TestBaseConvertInputLimit ensures oversized input is rejected before the
+// superlinear big.Int / O(n^2) base64 conversion runs.
+func TestBaseConvertInputLimit(t *testing.T) {
+	s := NewServer()
+	resp, err := s.BaseConvert(context.Background(), &pb.BaseConvertRequest{
+		Input: strings.Repeat("9", 10_001), SourceBase: 10,
+	})
+	if err != nil {
+		t.Fatalf("BaseConvert() error = %v", err)
+	}
+	if resp.Error == "" {
+		t.Error("BaseConvert() expected error for oversized input, got none")
+	}
+}
+
+// TestLeapYearListCap ensures the comma-separated form is bounded like the range
+// form (both capped at 400 entries).
+func TestLeapYearListCap(t *testing.T) {
+	s := NewServer()
+	years := make([]string, 500)
+	for i := range years {
+		years[i] = "2000"
+	}
+	resp, err := s.LeapYear(context.Background(), &pb.LeapYearRequest{Input: strings.Join(years, ",")})
+	if err != nil {
+		t.Fatalf("LeapYear() error = %v", err)
+	}
+	if resp.Error == "" {
+		t.Error("LeapYear() expected error for over-long list, got none")
+	}
+}
+
+// TestCaseConvertUnicode ensures the first character is treated as a rune, not a
+// byte, so a leading multi-byte character is not corrupted.
+func TestCaseConvertUnicode(t *testing.T) {
+	s := NewServer()
+	resp, err := s.CaseConvert(context.Background(), &pb.CaseRequest{Text: "über cafe"})
+	if err != nil {
+		t.Fatalf("CaseConvert() error = %v", err)
+	}
+	if resp.Pascal != "ÜberCafe" {
+		t.Errorf("Pascal = %q, want %q", resp.Pascal, "ÜberCafe")
+	}
+	if resp.Camel != "überCafe" {
+		t.Errorf("Camel = %q, want %q", resp.Camel, "überCafe")
+	}
+}
+
 // TestColorConvertRejectsOutOfRange ensures RGB components above 255 or
 // unparseable values are rejected rather than silently truncated.
 func TestColorConvertRejectsOutOfRange(t *testing.T) {

--- a/internal/api/text_handlers.go
+++ b/internal/api/text_handlers.go
@@ -190,7 +190,8 @@ func (s *Server) CaseConvert(ctx context.Context, req *pb.CaseRequest) (*pb.Case
 		res.WriteString(strings.ToLower(words[0]))
 		for _, w := range words[1:] {
 			if len(w) > 0 {
-				res.WriteString(strings.ToUpper(w[:1]) + strings.ToLower(w[1:]))
+				rw := []rune(w)
+				res.WriteString(strings.ToUpper(string(rw[:1])) + strings.ToLower(string(rw[1:])))
 			}
 		}
 		return res.String()
@@ -200,7 +201,8 @@ func (s *Server) CaseConvert(ctx context.Context, req *pb.CaseRequest) (*pb.Case
 		var res strings.Builder
 		for _, w := range words {
 			if len(w) > 0 {
-				res.WriteString(strings.ToUpper(w[:1]) + strings.ToLower(w[1:]))
+				rw := []rune(w)
+				res.WriteString(strings.ToUpper(string(rw[:1])) + strings.ToLower(string(rw[1:])))
 			}
 		}
 		return res.String()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -23,32 +25,75 @@ import (
 var staticFiles embed.FS
 
 type Server struct {
-	addr       string
-	rpcPath    string
-	rpcHandler http.Handler
+	addr         string
+	rpcPath      string
+	rpcHandler   http.Handler
+	allowedHosts map[string]struct{}
 }
 
 // New builds an HTTP server that routes connect RPC requests under rpcPath to
-// rpcHandler and serves the embedded React SPA for everything else.
-func New(addr, rpcPath string, rpcHandler http.Handler) *Server {
-	return &Server{
-		addr:       addr,
-		rpcPath:    rpcPath,
-		rpcHandler: rpcHandler,
+// rpcHandler and serves the embedded React SPA for everything else. allowedHosts
+// is the set of Host-header hostnames (no port) accepted for both request
+// admission and CORS — the DNS-rebinding / cross-origin defense.
+func New(addr, rpcPath string, rpcHandler http.Handler, allowedHosts []string) *Server {
+	set := make(map[string]struct{}, len(allowedHosts))
+	for _, h := range allowedHosts {
+		set[strings.ToLower(h)] = struct{}{}
 	}
+	return &Server{
+		addr:         addr,
+		rpcPath:      rpcPath,
+		rpcHandler:   rpcHandler,
+		allowedHosts: set,
+	}
+}
+
+// hostAllowed reports whether the given Host header (which may include a port)
+// has a hostname in the allowlist.
+func (s *Server) hostAllowed(hostport string) bool {
+	host := hostport
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	}
+	_, ok := s.allowedHosts[strings.ToLower(host)]
+	return ok
+}
+
+// allowedOrigin authorizes a CORS Origin whose hostname is in the allowlist
+// (any port/scheme) — scopes the RPC surface to localhost-family origins.
+func (s *Server) allowedOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	_, ok := s.allowedHosts[strings.ToLower(u.Hostname())]
+	return ok
+}
+
+// checkHost rejects requests whose Host header is not in the allowlist, the
+// canonical defense against DNS rebinding (which survives a loopback bind).
+func (s *Server) checkHost(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.hostAllowed(r.Host) {
+			http.Error(w, "forbidden: host not allowed", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (s *Server) newHandler(distFS fs.FS) http.Handler {
 	fileServer := http.FileServer(http.FS(distFS))
 
-	// Allow all origins, matching the previous grpc-web wrapper: PrivUtil is a
-	// local utility and is also used cross-origin from the Vite dev server. The
-	// connectcors helper supplies the headers the Connect/gRPC-Web protocols need.
+	// Scope CORS to the allowlisted hosts (localhost family + any configured
+	// host) instead of "*", so a website the user visits cannot read RPC
+	// responses cross-origin. The connectcors helper supplies the headers the
+	// Connect/gRPC-Web protocols need.
 	corsMiddleware := cors.New(cors.Options{
-		AllowedOrigins: []string{"*"},
-		AllowedMethods: connectcors.AllowedMethods(),
-		AllowedHeaders: connectcors.AllowedHeaders(),
-		ExposedHeaders: connectcors.ExposedHeaders(),
+		AllowOriginFunc: s.allowedOrigin,
+		AllowedMethods:  connectcors.AllowedMethods(),
+		AllowedHeaders:  connectcors.AllowedHeaders(),
+		ExposedHeaders:  connectcors.ExposedHeaders(),
 	})
 
 	mux := http.NewServeMux()
@@ -70,19 +115,35 @@ func (s *Server) newHandler(distFS fs.FS) http.Handler {
 
 	// Serve cleartext HTTP/2 (h2c) so native gRPC clients work without TLS; the
 	// browser uses gRPC-Web over HTTP/1.1, which the same handler also serves.
-	return h2c.NewHandler(securityHeaders(mux), &http2.Server{})
+	// checkHost runs first (rebinding defense), then security headers, then mux.
+	return h2c.NewHandler(securityHeaders(s.checkHost(mux)), &http2.Server{})
 }
 
-// securityHeaders adds conservative hardening headers to every response. A
-// full Content-Security-Policy is intentionally omitted here to avoid breaking
-// the SPA's inline assets; untrusted markup is already isolated in sandboxed
-// iframes by the client.
+// contentSecurityPolicy backstops the SPA's parent origin. Scripts must be
+// same-origin ('self', no inline/eval); the theme bootstrap is an external
+// /theme.js for that reason. Preview iframes (srcDoc/blob) need frame-src, and
+// decoded media needs data:/blob: in img/frame-src. Untrusted markup is still
+// isolated in per-iframe sandboxes with their own stricter CSP.
+const contentSecurityPolicy = "default-src 'self'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data: blob:; " +
+	"media-src 'self' data: blob:; " + // decoded audio/video preview (blob URLs)
+	"font-src 'self' data:; " +
+	"connect-src 'self'; " +
+	"frame-src 'self' data: blob:; " +
+	"object-src 'none'; " +
+	"base-uri 'none'; " +
+	"frame-ancestors 'none'"
+
+// securityHeaders adds hardening headers to every response.
 func securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("Content-Security-Policy", contentSecurityPolicy)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNew(t *testing.T) {
 	rpcHandler := http.NewServeMux()
-	srv := New(":8090", "/privutil.PrivUtilService/", rpcHandler)
+	srv := New(":8090", "/privutil.PrivUtilService/", rpcHandler, []string{"localhost", "127.0.0.1"})
 
 	if srv == nil {
 		t.Fatal("New() returned nil")
@@ -38,7 +38,43 @@ func testHandler(t *testing.T) http.Handler {
 	if err != nil {
 		t.Fatalf("fs.Sub: %v", err)
 	}
-	return New(":0", "/privutil.PrivUtilService/", http.NewServeMux()).newHandler(distFS)
+	return New(":0", "/privutil.PrivUtilService/", http.NewServeMux(), []string{"localhost", "127.0.0.1", "::1"}).newHandler(distFS)
+}
+
+func TestHostAllowlistAndCSP(t *testing.T) {
+	ts := httptest.NewServer(testHandler(t))
+	defer ts.Close()
+	client := ts.Client()
+
+	cases := []struct {
+		name string
+		host string
+		want int
+	}{
+		{"loopback ip allowed", "127.0.0.1", http.StatusOK},
+		{"localhost allowed", "localhost", http.StatusOK},
+		{"foreign host blocked", "evil.example.com", http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, ts.URL+"/", nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Host = tc.host
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != tc.want {
+				t.Errorf("Host %q status = %d, want %d", tc.host, resp.StatusCode, tc.want)
+			}
+			if tc.want == http.StatusOK && resp.Header.Get("Content-Security-Policy") == "" {
+				t.Error("expected Content-Security-Policy header on allowed request")
+			}
+		})
+	}
 }
 
 func TestServerHandlerStaticFiles(t *testing.T) {

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PrivUtil</title>
-    <script>if (localStorage.getItem('theme') !== 'light') document.documentElement.classList.add('dark');</script>
+    <script src="/theme.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/public/theme.js
+++ b/web/public/theme.js
@@ -1,0 +1,5 @@
+// Applies the persisted theme before first paint. External (not inline) so the
+// app's Content-Security-Policy can use script-src 'self' with no 'unsafe-inline'.
+if (localStorage.getItem('theme') !== 'light') {
+  document.documentElement.classList.add('dark');
+}

--- a/web/src/components/HtmlMarkdownViewer.tsx
+++ b/web/src/components/HtmlMarkdownViewer.tsx
@@ -109,25 +109,33 @@ ${bodyHtml}
 </html>`;
 }
 
+// Monotonic counter so overlapping renderMermaid calls (rapid edits) never reuse
+// a mermaid diagram id — mermaid keys a transient live-DOM measuring node off the
+// id, and colliding ids across concurrent renders throw or orphan nodes.
+let mermaidRunSeq = 0;
+
 // renderMermaid replaces goldmark's <pre class="mermaid"> blocks with static SVG
 // produced by the bundled mermaid library (securityLevel 'strict'), so the
 // preview iframe never needs to run scripts or fetch mermaid.js from a CDN.
 async function renderMermaid(html: string): Promise<string> {
   const doc = new DOMParser().parseFromString(html, 'text/html');
-  const blocks = Array.from(doc.querySelectorAll<HTMLElement>('pre.mermaid, .mermaid'));
+  // Only goldmark's own <pre class="mermaid"> output; not arbitrary .mermaid
+  // elements a user's raw HTML might contain.
+  const blocks = Array.from(doc.querySelectorAll<HTMLElement>('pre.mermaid'));
   if (blocks.length === 0) return html;
 
   const mermaid = (await import('mermaid')).default;
   const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: dark ? 'dark' : 'default' });
 
+  const runId = ++mermaidRunSeq;
   for (let i = 0; i < blocks.length; i++) {
     const el = blocks[i];
     const code = el.textContent ?? '';
     const wrapper = doc.createElement('div');
     wrapper.className = 'mermaid';
     try {
-      const { svg } = await mermaid.render(`mermaid-diagram-${i}`, code);
+      const { svg } = await mermaid.render(`mermaid-${runId}-${i}`, code);
       wrapper.innerHTML = svg;
     } catch (err) {
       const pre = doc.createElement('pre');
@@ -144,6 +152,7 @@ export function HtmlMarkdownViewer() {
   const [input, setInput] = useState<string>(SAMPLE_MD);
   const [renderedHtml, setRenderedHtml] = useState<string>('');
   const [mermaidHtml, setMermaidHtml] = useState<string>('');
+  const [mermaidSrc, setMermaidSrc] = useState<string>('');
   const [allowImages, setAllowImages] = useState(false);
   const [enableMermaid, setEnableMermaid] = useState(false);
   const [showSource, setShowSource] = useState(false);
@@ -203,17 +212,24 @@ export function HtmlMarkdownViewer() {
   }, [maximized]);
 
   // Render mermaid blocks to SVG in-app so the preview stays script-free; the
-  // async result feeds mermaidHtml, used only while the toggle is on.
+  // async result feeds mermaidHtml, tagged with the source it was rendered from.
   useEffect(() => {
     if (!enableMermaid) return;
     let cancelled = false;
     void renderMermaid(renderedHtml).then((html) => {
-      if (!cancelled) setMermaidHtml(html);
+      if (cancelled) return;
+      setMermaidHtml(html);
+      setMermaidSrc(renderedHtml);
     });
     return () => { cancelled = true; };
   }, [renderedHtml, enableMermaid]);
 
-  const bodyHtml = enableMermaid ? mermaidHtml : renderedHtml;
+  // While mermaid is on but its render for the *current* document hasn't landed,
+  // show a placeholder instead of a blank (first toggle) or stale (mid-edit) body.
+  const mermaidBusy = enableMermaid && mermaidSrc !== renderedHtml;
+  const bodyHtml = mermaidBusy
+    ? '<p style="opacity:0.6">Rendering diagrams…</p>'
+    : enableMermaid ? mermaidHtml : renderedHtml;
   const srcDoc = useMemo(
     () => buildSrcDoc(bodyHtml, allowImages),
     [bodyHtml, allowImages],
@@ -353,7 +369,7 @@ export function HtmlMarkdownViewer() {
           </button>
           <button
             onClick={downloadHtml}
-            disabled={!renderedHtml}
+            disabled={!renderedHtml || mermaidBusy}
             className="text-sm px-3 py-1.5 rounded bg-slate-100 dark:bg-neutral-700 hover:bg-slate-200 dark:hover:bg-neutral-600 text-slate-700 dark:text-slate-200 transition-colors disabled:opacity-40 flex items-center gap-1.5">
             <Download className="w-4 h-4" /> Download HTML
           </button>


### PR DESCRIPTION
Fourth review-and-fix iteration (4 parallel review agents; all prior fixes re-verified, no regressions). Four commits, grouped by domain.

## Backend
- **BaseConvert DoS (HIGH)** — no input cap; big.Int + an O(n²) base64 loop meant ~500 KB pinned a core ~50 s. Capped at 10k chars.
- LeapYear comma-list capped at 400 (like the range form).
- CaseConvert/toPascalCase sliced the first **byte**, corrupting leading multi-byte chars (`über`) — now rune-aware. +3 tests.

## Frontend (mermaid follow-ups)
- Loading placeholder so enabling the toggle no longer blanks the preview and mid-edit no longer shows a stale diagram.
- Unique per-run render IDs (no collisions on rapid edits); tighter `pre.mermaid` selector; download gated while rendering.

## CI / supply-chain
- **SHA-pinned every remaining action** (the docker job holds `id-token: write` for signing — an unpinned action there could exfiltrate the OIDC token).
- Pinned base-image digests; `contents: read` on build/test/lint; added the `github-actions` Dependabot ecosystem.

## Network defense (the recurring HIGH)
- Default **HOST → 127.0.0.1** (matches docs) with `ENV HOST=0.0.0.0` in the Dockerfile so containers stay reachable.
- **Host-header allowlist** (localhost family + configured host + `ALLOWED_HOSTS`) — DNS-rebinding defense; foreign Host → 403.
- **Scoped CORS** (allowlist-based `AllowOriginFunc`, no more `*`).
- **CSP** on the SPA (`script-src 'self'`, no inline/eval); inline theme bootstrap moved to `/theme.js`; `media-src` covers decoded audio/video blobs.

## Verification
`make lint` + `make test` green (incl. new backend + server tests). Runtime smoke test confirmed: loopback bind, CSP header present, foreign Host → 403, RPCs over localhost still work.

## ⚠️ Needs a manual in-browser check before merge
1. **Mermaid under CSP** — `script-src 'self'` (no eval): confirm diagrams still render (Viewer → enable "Mermaid diagrams" on the sample). If mermaid needs eval/workers, the CSP's `script-src`/`worker-src` may need adjusting.
2. General CSP smoke — load a few tools, confirm no console CSP violations and dark-mode has no flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)