### PR TITLE
feat(spellcheck): server-side custom dictionary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,14 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-go BUILD_VERSION=${VERSION}
 
 FROM alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
-RUN addgroup -S privutil && adduser -S privutil -G privutil
+RUN addgroup -S privutil && adduser -S privutil -G privutil \
+    && mkdir -p /data && chown privutil:privutil /data
 COPY --from=build /PrivUtil/privutil /bin/privutil
 USER privutil
+# Persist the spellchecker custom dictionary under /data; mount a volume
+# (e.g. -v privutil-data:/data) to keep it across container restarts.
+ENV CUSTOM_DICT=/data/custom-dictionary.txt
+VOLUME /data
 # The binary now defaults to loopback; containers must bind all interfaces to be
 # reachable via port mapping. Access is still gated by the Host-header allowlist
 # (localhost/127.0.0.1 by default; set ALLOWED_HOSTS for LAN/custom domains).

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,13 @@ RUN addgroup -S privutil && adduser -S privutil -G privutil \
     && mkdir -p /data && chown privutil:privutil /data
 COPY --from=build /PrivUtil/privutil /bin/privutil
 USER privutil
-# Persist the spellchecker custom dictionary under /data; mount a volume
-# (e.g. -v privutil-data:/data) to keep it across container restarts.
+# The spellchecker custom dictionary is written under /data. Mount a NAMED
+# volume to persist it, e.g.  docker run -v privutil-data:/data ...
+# No VOLUME is declared on purpose: it would spawn a throwaway anonymous volume
+# on every container recreation (silently losing the dictionary and leaking
+# orphaned volumes). A bind-mounted host directory must be chown'd to the
+# container's privutil user (or run with a matching --user) to be writable.
 ENV CUSTOM_DICT=/data/custom-dictionary.txt
-VOLUME /data
 # The binary now defaults to loopback; containers must bind all interfaces to be
 # reachable via port mapping. Access is still gated by the Host-header allowlist
 # (localhost/127.0.0.1 by default; set ALLOWED_HOSTS for LAN/custom domains).

--- a/cmd/privutil/main.go
+++ b/cmd/privutil/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	connect "connectrpc.com/connect"
@@ -32,6 +33,7 @@ func main() {
 	port := flag.String("port", getEnvOrDefault("PORT", "8090"), "Port to listen on")
 	host := flag.String("host", getEnvOrDefault("HOST", "127.0.0.1"), "Host to bind to (default: loopback; use 0.0.0.0 for all interfaces)")
 	allowedHosts := flag.String("allowed-hosts", getEnvOrDefault("ALLOWED_HOSTS", ""), "Comma-separated extra Host header values to accept (for LAN/custom-domain access)")
+	customDict := flag.String("custom-dict", getEnvOrDefault("CUSTOM_DICT", defaultCustomDictPath()), "Path to the spellchecker custom-dictionary file (empty disables persistence)")
 	logLevel := flag.String("log-level", getEnvOrDefault("LOG_LEVEL", "info"), "Log level: debug, info (debug adds file/line to log output)")
 	version := flag.Bool("version", false, "Print version and exit")
 
@@ -44,6 +46,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  PORT           Port to listen on (default: 8090)\n")
 		fmt.Fprintf(os.Stderr, "  HOST           Host to bind to (default: 127.0.0.1; use 0.0.0.0 for all interfaces)\n")
 		fmt.Fprintf(os.Stderr, "  ALLOWED_HOSTS  Extra Host header values to accept, comma-separated\n")
+		fmt.Fprintf(os.Stderr, "  CUSTOM_DICT    Path to the spellchecker custom-dictionary file\n")
 		fmt.Fprintf(os.Stderr, "  LOG_LEVEL      Log level (default: info)\n")
 	}
 
@@ -67,7 +70,7 @@ func main() {
 	// WithReadMaxBytes bounds every RPC body (default is unlimited), capping the
 	// memory/CPU amplification available to abusive requests. The media handlers
 	// enforce their own stricter 10 MB limits on top of this.
-	connectSrv := api.NewConnectServer(api.NewServer())
+	connectSrv := api.NewConnectServer(api.NewServer(api.WithCustomDictPath(*customDict)))
 	rpcPath, rpcHandler := protoconnect.NewPrivUtilServiceHandler(
 		connectSrv,
 		connect.WithInterceptors(api.RecoveryInterceptor(*logLevel == "debug")),
@@ -99,6 +102,18 @@ func buildAllowedHosts(bindHost, extra string) []string {
 		}
 	}
 	return hosts
+}
+
+// defaultCustomDictPath returns the per-user location for the spellchecker's
+// custom dictionary (e.g. ~/.config/privutil/custom-dictionary.txt), or "" when
+// the OS config dir can't be determined — in which case the dictionary is
+// in-memory only until a path is set via -custom-dict / CUSTOM_DICT.
+func defaultCustomDictPath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "privutil", "custom-dictionary.txt")
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/internal/api/connect_adapter.go
+++ b/internal/api/connect_adapter.go
@@ -630,3 +630,27 @@ func (a *ConnectServer) SpellLanguages(ctx context.Context, r *connect.Request[p
 	}
 	return connect.NewResponse(resp), nil
 }
+
+func (a *ConnectServer) GetCustomWords(ctx context.Context, r *connect.Request[pb.GetCustomWordsRequest]) (*connect.Response[pb.CustomWordsResponse], error) {
+	resp, err := a.s.GetCustomWords(ctx, r.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *ConnectServer) AddCustomWords(ctx context.Context, r *connect.Request[pb.AddCustomWordsRequest]) (*connect.Response[pb.CustomWordsResponse], error) {
+	resp, err := a.s.AddCustomWords(ctx, r.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *ConnectServer) RemoveCustomWord(ctx context.Context, r *connect.Request[pb.RemoveCustomWordRequest]) (*connect.Response[pb.CustomWordsResponse], error) {
+	resp, err := a.s.RemoveCustomWord(ctx, r.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}

--- a/internal/api/custom_dict.go
+++ b/internal/api/custom_dict.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+const (
+	maxCustomWords   = 10_000 // cap the total number of custom words
+	maxCustomWordLen = 64     // cap the length of a single custom word (runes)
+)
+
+// customDict is a thread-safe, file-backed set of extra accepted words for the
+// spellchecker, shared across languages. Words are stored lowercased; matching
+// is case-insensitive. An empty path keeps the dictionary in memory only (no
+// persistence) — used by tests and when no dictionary file is configured.
+type customDict struct {
+	mu    sync.RWMutex
+	path  string
+	words map[string]struct{}
+}
+
+// newCustomDict builds a dictionary backed by path (loading it if present). A
+// missing or unreadable file is not an error: the dictionary simply starts empty.
+func newCustomDict(path string) *customDict {
+	d := &customDict{path: path, words: make(map[string]struct{})}
+	d.load()
+	return d
+}
+
+func (d *customDict) load() {
+	if d.path == "" {
+		return
+	}
+	f, err := os.Open(d.path) // #nosec G304 -- path is operator-configured (flag/env), not user input
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if w := normalizeCustomWord(sc.Text()); w != "" {
+			d.words[w] = struct{}{}
+		}
+	}
+}
+
+// Has implements spellcheck.Lookup: reports whether word (case-insensitively) is
+// in the custom dictionary.
+func (d *customDict) Has(word string) bool {
+	w := normalizeCustomWord(word)
+	if w == "" {
+		return false
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	_, ok := d.words[w]
+	return ok
+}
+
+// List returns the custom words, sorted.
+func (d *customDict) List() []string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.sortedLocked()
+}
+
+func (d *customDict) sortedLocked() []string {
+	out := make([]string, 0, len(d.words))
+	for w := range d.words {
+		out = append(out, w)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Add inserts words (each entry may contain several whitespace-separated words)
+// and persists. Returns the full list after the operation.
+func (d *customDict) Add(words []string) ([]string, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, raw := range words {
+		for _, tok := range strings.Fields(raw) {
+			w := normalizeCustomWord(tok)
+			if w == "" {
+				continue
+			}
+			if len([]rune(w)) > maxCustomWordLen {
+				return d.sortedLocked(), fmt.Errorf("word %q is too long (limit %d characters)", tok, maxCustomWordLen)
+			}
+			if _, ok := d.words[w]; ok {
+				continue
+			}
+			if len(d.words) >= maxCustomWords {
+				return d.sortedLocked(), fmt.Errorf("custom dictionary is full (limit %d words)", maxCustomWords)
+			}
+			d.words[w] = struct{}{}
+		}
+	}
+	if err := d.persistLocked(); err != nil {
+		return d.sortedLocked(), err
+	}
+	return d.sortedLocked(), nil
+}
+
+// Remove deletes a word and persists. Removing an absent word is a no-op.
+func (d *customDict) Remove(word string) ([]string, error) {
+	w := normalizeCustomWord(word)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.words, w)
+	if err := d.persistLocked(); err != nil {
+		return d.sortedLocked(), err
+	}
+	return d.sortedLocked(), nil
+}
+
+// persistLocked writes the dictionary atomically (temp file + rename). It is a
+// no-op when the dictionary is in-memory only (empty path). Caller holds d.mu.
+func (d *customDict) persistLocked() error {
+	if d.path == "" {
+		return nil
+	}
+	dir := filepath.Dir(d.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create dictionary directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".custom-dict-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+
+	w := bufio.NewWriter(tmp)
+	for _, word := range d.sortedLocked() {
+		if _, err := fmt.Fprintln(w, word); err != nil {
+			_ = tmp.Close()
+			return err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, d.path)
+}
+
+// normalizeCustomWord lowercases and trims a stored/looked-up word.
+func normalizeCustomWord(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}

--- a/internal/api/custom_dict.go
+++ b/internal/api/custom_dict.go
@@ -160,7 +160,8 @@ func (d *customDict) persistLocked() error {
 		return nil
 	}
 	dir := filepath.Dir(d.path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// 0700: the dictionary is per-user data; keep its directory private.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create dictionary directory: %w", err)
 	}
 	tmp, err := os.CreateTemp(dir, ".custom-dict-*.tmp")

--- a/internal/api/custom_dict.go
+++ b/internal/api/custom_dict.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"unicode"
 )
 
 const (
@@ -44,7 +45,7 @@ func (d *customDict) load() {
 	defer f.Close()
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
-		if w := normalizeCustomWord(sc.Text()); w != "" {
+		if w := normalizeCustomWord(sc.Text()); w != "" && !hasControlChar(w) {
 			d.words[w] = struct{}{}
 		}
 	}
@@ -80,10 +81,15 @@ func (d *customDict) sortedLocked() []string {
 }
 
 // Add inserts words (each entry may contain several whitespace-separated words)
-// and persists. Returns the full list after the operation.
+// and persists. It is transactional: every token is validated first, so an
+// invalid word (too long, control characters) or hitting the cap rejects the
+// whole batch without mutating memory or disk. On a persist failure the added
+// words are rolled back so the in-memory set never gets ahead of the file.
+// Returns the full list after the operation.
 func (d *customDict) Add(words []string) ([]string, error) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	// Validate + dedupe candidate tokens before taking the write lock.
+	var candidates []string
+	seen := make(map[string]struct{})
 	for _, raw := range words {
 		for _, tok := range strings.Fields(raw) {
 			w := normalizeCustomWord(tok)
@@ -91,30 +97,57 @@ func (d *customDict) Add(words []string) ([]string, error) {
 				continue
 			}
 			if len([]rune(w)) > maxCustomWordLen {
-				return d.sortedLocked(), fmt.Errorf("word %q is too long (limit %d characters)", tok, maxCustomWordLen)
+				return d.List(), fmt.Errorf("word %q is too long (limit %d characters)", tok, maxCustomWordLen)
 			}
-			if _, ok := d.words[w]; ok {
-				continue
+			if hasControlChar(w) {
+				return d.List(), fmt.Errorf("word %q contains control characters", tok)
 			}
-			if len(d.words) >= maxCustomWords {
-				return d.sortedLocked(), fmt.Errorf("custom dictionary is full (limit %d words)", maxCustomWords)
+			if _, dup := seen[w]; !dup {
+				seen[w] = struct{}{}
+				candidates = append(candidates, w)
 			}
-			d.words[w] = struct{}{}
 		}
 	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var added []string
+	for _, w := range candidates {
+		if _, ok := d.words[w]; !ok {
+			added = append(added, w)
+		}
+	}
+	if len(added) == 0 {
+		return d.sortedLocked(), nil // nothing new: skip the rewrite
+	}
+	if len(d.words)+len(added) > maxCustomWords {
+		return d.sortedLocked(), fmt.Errorf("custom dictionary is full (limit %d words)", maxCustomWords)
+	}
+	for _, w := range added {
+		d.words[w] = struct{}{}
+	}
 	if err := d.persistLocked(); err != nil {
+		for _, w := range added {
+			delete(d.words, w) // roll back so memory matches the unchanged file
+		}
 		return d.sortedLocked(), err
 	}
 	return d.sortedLocked(), nil
 }
 
-// Remove deletes a word and persists. Removing an absent word is a no-op.
+// Remove deletes a word and persists. Removing an absent word is a no-op (no
+// file rewrite). On a persist failure the deletion is rolled back.
 func (d *customDict) Remove(word string) ([]string, error) {
 	w := normalizeCustomWord(word)
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if _, ok := d.words[w]; !ok {
+		return d.sortedLocked(), nil
+	}
 	delete(d.words, w)
 	if err := d.persistLocked(); err != nil {
+		d.words[w] = struct{}{} // roll back
 		return d.sortedLocked(), err
 	}
 	return d.sortedLocked(), nil
@@ -148,6 +181,12 @@ func (d *customDict) persistLocked() error {
 		_ = tmp.Close()
 		return err
 	}
+	// fsync before the rename so the data is durable, not just atomically
+	// swapped — otherwise a crash after rename can leave a truncated file.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
 	if err := tmp.Close(); err != nil {
 		return err
 	}
@@ -157,4 +196,11 @@ func (d *customDict) persistLocked() error {
 // normalizeCustomWord lowercases and trims a stored/looked-up word.
 func normalizeCustomWord(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// hasControlChar reports whether s contains any control character, so such
+// words are never stored (they can inject ANSI escapes when the dictionary file
+// is later viewed in a terminal).
+func hasControlChar(s string) bool {
+	return strings.IndexFunc(s, unicode.IsControl) >= 0
 }

--- a/internal/api/custom_dict_test.go
+++ b/internal/api/custom_dict_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pb "github.com/odinnordico/privutil/proto"
+)
+
+func TestCustomDictAddListRemove(t *testing.T) {
+	d := newCustomDict(filepath.Join(t.TempDir(), "dict.txt"))
+
+	if _, err := d.Add([]string{"Foo", "bar baz", "foo"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// Stored lowercased, deduped, whitespace-split, sorted.
+	if got := d.List(); strings.Join(got, ",") != "bar,baz,foo" {
+		t.Errorf("List = %v, want [bar baz foo]", got)
+	}
+	if !d.Has("FOO") || !d.Has("foo") {
+		t.Error("Has should be case-insensitive")
+	}
+	if _, err := d.Remove("BAR"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if d.Has("bar") {
+		t.Error("bar should be removed")
+	}
+}
+
+func TestCustomDictPersistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "dict.txt") // dir must be created on write
+
+	d1 := newCustomDict(path)
+	if _, err := d1.Add([]string{"widget", "gizmo"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("dictionary file not written: %v", err)
+	}
+
+	// A fresh instance on the same path loads the persisted words.
+	d2 := newCustomDict(path)
+	if !d2.Has("widget") || !d2.Has("gizmo") {
+		t.Errorf("reloaded dict missing words: %v", d2.List())
+	}
+}
+
+func TestCustomDictValidation(t *testing.T) {
+	d := newCustomDict("") // in-memory
+	long := strings.Repeat("a", maxCustomWordLen+1)
+	if _, err := d.Add([]string{long}); err == nil {
+		t.Error("expected error for over-long word")
+	}
+	if d.Has(long) {
+		t.Error("over-long word should not have been stored")
+	}
+}
+
+func TestCustomDictInMemoryNoFile(t *testing.T) {
+	d := newCustomDict("")
+	if _, err := d.Add([]string{"ephemeral"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !d.Has("ephemeral") {
+		t.Error("in-memory add failed")
+	}
+}
+
+// TestSpellCheckHonorsCustomDict verifies an added word stops being flagged.
+func TestSpellCheckHonorsCustomDict(t *testing.T) {
+	s := NewServer(WithCustomDictPath(filepath.Join(t.TempDir(), "dict.txt")))
+	ctx := context.Background()
+	const word = "zzblarg"
+
+	before, err := s.SpellCheck(ctx, &pb.SpellCheckRequest{Text: "hello " + word + " world"})
+	if err != nil {
+		t.Fatalf("SpellCheck: %v", err)
+	}
+	if !flagsWord(before.Issues, word) {
+		t.Fatalf("expected %q to be flagged before adding it", word)
+	}
+
+	if _, err := s.AddCustomWords(ctx, &pb.AddCustomWordsRequest{Words: []string{word}}); err != nil {
+		t.Fatalf("AddCustomWords: %v", err)
+	}
+
+	after, err := s.SpellCheck(ctx, &pb.SpellCheckRequest{Text: "hello " + word + " world"})
+	if err != nil {
+		t.Fatalf("SpellCheck: %v", err)
+	}
+	if flagsWord(after.Issues, word) {
+		t.Errorf("%q should not be flagged after adding to the custom dictionary", word)
+	}
+
+	got, err := s.GetCustomWords(ctx, &pb.GetCustomWordsRequest{})
+	if err != nil {
+		t.Fatalf("GetCustomWords: %v", err)
+	}
+	if len(got.Words) != 1 || got.Words[0] != word {
+		t.Errorf("GetCustomWords = %v, want [%s]", got.Words, word)
+	}
+}
+
+func flagsWord(issues []*pb.SpellIssue, word string) bool {
+	for _, is := range issues {
+		if strings.EqualFold(is.Text, word) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/custom_dict_test.go
+++ b/internal/api/custom_dict_test.go
@@ -52,11 +52,26 @@ func TestCustomDictPersistence(t *testing.T) {
 func TestCustomDictValidation(t *testing.T) {
 	d := newCustomDict("") // in-memory
 	long := strings.Repeat("a", maxCustomWordLen+1)
-	if _, err := d.Add([]string{long}); err == nil {
+
+	// A batch with an invalid token is rejected atomically: the valid token
+	// ("good") that precedes it must NOT be stored.
+	if _, err := d.Add([]string{"good", long}); err == nil {
 		t.Error("expected error for over-long word")
 	}
 	if d.Has(long) {
 		t.Error("over-long word should not have been stored")
+	}
+	if d.Has("good") {
+		t.Error("Add must be transactional: a valid word in a failing batch must not persist")
+	}
+
+	// Control characters are rejected (they could inject ANSI escapes into the
+	// dictionary file when viewed in a terminal).
+	if _, err := d.Add([]string{"a\x1b[2Jb"}); err == nil {
+		t.Error("expected error for word with control characters")
+	}
+	if len(d.List()) != 0 {
+		t.Errorf("dictionary should be empty, got %v", d.List())
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3,8 +3,25 @@ package api
 // Server holds the implementations of all PrivUtil RPC handlers. The handlers
 // are defined as methods across the *_handlers.go files in this package and are
 // exposed via the connect adapter in connect_adapter.go.
-type Server struct{}
+type Server struct {
+	custom *customDict
+}
 
-func NewServer() *Server {
-	return &Server{}
+// Option configures a Server.
+type Option func(*Server)
+
+// WithCustomDictPath backs the spellchecker's custom dictionary with a file at
+// path. An empty path (the default) keeps it in memory only.
+func WithCustomDictPath(path string) Option {
+	return func(s *Server) { s.custom = newCustomDict(path) }
+}
+
+// NewServer builds a Server. By default the custom dictionary is in-memory only;
+// pass WithCustomDictPath to persist it.
+func NewServer(opts ...Option) *Server {
+	s := &Server{custom: newCustomDict("")}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }

--- a/internal/api/spell_handlers.go
+++ b/internal/api/spell_handlers.go
@@ -30,7 +30,7 @@ func (s *Server) SpellCheck(ctx context.Context, req *pb.SpellCheckRequest) (*pb
 		}, nil
 	}
 
-	issues, lang := spellcheck.Check(req.Text, req.Language)
+	issues, lang := spellcheck.CheckWithCustom(req.Text, req.Language, s.custom)
 
 	out := make([]*pb.SpellIssue, 0, len(issues))
 	for _, is := range issues {
@@ -54,6 +54,29 @@ func (s *Server) SpellCheck(ctx context.Context, req *pb.SpellCheckRequest) (*pb
 		Language:  lang,
 		WordCount: int32(spellcheck.WordCount(req.Text)), // #nosec G115
 	}, nil
+}
+
+// GetCustomWords returns the current custom-dictionary word list.
+func (s *Server) GetCustomWords(_ context.Context, _ *pb.GetCustomWordsRequest) (*pb.CustomWordsResponse, error) {
+	return &pb.CustomWordsResponse{Words: s.custom.List()}, nil
+}
+
+// AddCustomWords adds words to the custom dictionary and returns the full list.
+func (s *Server) AddCustomWords(_ context.Context, req *pb.AddCustomWordsRequest) (*pb.CustomWordsResponse, error) {
+	words, err := s.custom.Add(req.Words)
+	if err != nil {
+		return &pb.CustomWordsResponse{Words: words, Error: err.Error()}, nil
+	}
+	return &pb.CustomWordsResponse{Words: words}, nil
+}
+
+// RemoveCustomWord removes a word from the custom dictionary.
+func (s *Server) RemoveCustomWord(_ context.Context, req *pb.RemoveCustomWordRequest) (*pb.CustomWordsResponse, error) {
+	words, err := s.custom.Remove(req.Word)
+	if err != nil {
+		return &pb.CustomWordsResponse{Words: words, Error: err.Error()}, nil
+	}
+	return &pb.CustomWordsResponse{Words: words}, nil
 }
 
 // SpellLanguages reports the languages supported by the offline engine.

--- a/internal/spellcheck/spellcheck.go
+++ b/internal/spellcheck/spellcheck.go
@@ -50,10 +50,21 @@ func Languages() []LanguageInfo {
 	return out
 }
 
+// Lookup is an optional extra dictionary consulted in addition to the built-in
+// one — a word it accepts is never flagged as a spelling mistake. Membership is
+// expected to be case-insensitive.
+type Lookup interface {
+	Has(word string) bool
+}
+
 // Check runs spelling and grammar checks over text in the given language.
-// It returns the issues, the resolved language code, and (for symmetry with
-// other engines) an error slot that is currently always nil.
 func Check(text, lang string) ([]Issue, string) {
+	return CheckWithCustom(text, lang, nil)
+}
+
+// CheckWithCustom is Check plus a custom dictionary whose words are treated as
+// correctly spelled. Pass nil for custom to get the default behavior.
+func CheckWithCustom(text, lang string, custom Lookup) ([]Issue, string) {
 	if lang == "" {
 		lang = DefaultLanguage
 	}
@@ -61,7 +72,7 @@ func Check(text, lang string) ([]Issue, string) {
 	if !ok {
 		l, lang = registry[DefaultLanguage], DefaultLanguage
 	}
-	return l.check([]rune(text)), lang
+	return l.check([]rune(text), custom), lang
 }
 
 // WordCount counts word tokens in text (language-independent).
@@ -69,8 +80,8 @@ func WordCount(text string) int {
 	return len(tokenizeWords([]rune(text)))
 }
 
-func (l *Language) check(runes []rune) []Issue {
-	issues := l.spellingIssues(runes)
+func (l *Language) check(runes []rune, custom Lookup) []Issue {
+	issues := l.spellingIssues(runes, custom)
 	for _, rule := range l.rules {
 		issues = append(issues, rule(runes)...)
 	}
@@ -81,7 +92,7 @@ func (l *Language) check(runes []rune) []Issue {
 // suggestions. Capitalized words that aren't at a sentence start are treated as
 // likely proper nouns and only flagged when a strong (edit-distance-1)
 // correction exists.
-func (l *Language) spellingIssues(runes []rune) []Issue {
+func (l *Language) spellingIssues(runes []rune, custom Lookup) []Issue {
 	var issues []Issue
 	for _, t := range tokenizeWords(runes) {
 		w := trimApostrophes(t.text)
@@ -94,6 +105,9 @@ func (l *Language) spellingIssues(runes []rune) []Issue {
 		}
 		if l.dict.contains(w) || acceptedContraction(l.dict, w) {
 			continue
+		}
+		if custom != nil && custom.Has(w) {
+			continue // user's custom dictionary
 		}
 
 		titleCased := unicode.IsUpper(rw[0]) && !isAllUpper(w)

--- a/proto/privutil.pb.go
+++ b/proto/privutil.pb.go
@@ -9801,6 +9801,184 @@ func (x *SpellLanguagesResponse) GetLanguages() []*SpellLanguage {
 	return nil
 }
 
+// Custom dictionary: a server-side, persisted list of extra accepted words,
+// shared across all languages. SpellCheck consults it automatically.
+type GetCustomWordsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCustomWordsRequest) Reset() {
+	*x = GetCustomWordsRequest{}
+	mi := &file_proto_privutil_proto_msgTypes[152]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCustomWordsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCustomWordsRequest) ProtoMessage() {}
+
+func (x *GetCustomWordsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_privutil_proto_msgTypes[152]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCustomWordsRequest.ProtoReflect.Descriptor instead.
+func (*GetCustomWordsRequest) Descriptor() ([]byte, []int) {
+	return file_proto_privutil_proto_rawDescGZIP(), []int{152}
+}
+
+type AddCustomWordsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Words         []string               `protobuf:"bytes,1,rep,name=words,proto3" json:"words,omitempty"` // words to add (whitespace/case normalized server-side)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddCustomWordsRequest) Reset() {
+	*x = AddCustomWordsRequest{}
+	mi := &file_proto_privutil_proto_msgTypes[153]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddCustomWordsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddCustomWordsRequest) ProtoMessage() {}
+
+func (x *AddCustomWordsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_privutil_proto_msgTypes[153]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddCustomWordsRequest.ProtoReflect.Descriptor instead.
+func (*AddCustomWordsRequest) Descriptor() ([]byte, []int) {
+	return file_proto_privutil_proto_rawDescGZIP(), []int{153}
+}
+
+func (x *AddCustomWordsRequest) GetWords() []string {
+	if x != nil {
+		return x.Words
+	}
+	return nil
+}
+
+type RemoveCustomWordRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Word          string                 `protobuf:"bytes,1,opt,name=word,proto3" json:"word,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveCustomWordRequest) Reset() {
+	*x = RemoveCustomWordRequest{}
+	mi := &file_proto_privutil_proto_msgTypes[154]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveCustomWordRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveCustomWordRequest) ProtoMessage() {}
+
+func (x *RemoveCustomWordRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_privutil_proto_msgTypes[154]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveCustomWordRequest.ProtoReflect.Descriptor instead.
+func (*RemoveCustomWordRequest) Descriptor() ([]byte, []int) {
+	return file_proto_privutil_proto_rawDescGZIP(), []int{154}
+}
+
+func (x *RemoveCustomWordRequest) GetWord() string {
+	if x != nil {
+		return x.Word
+	}
+	return ""
+}
+
+type CustomWordsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Words         []string               `protobuf:"bytes,1,rep,name=words,proto3" json:"words,omitempty"` // the full custom word list after the operation, sorted
+	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CustomWordsResponse) Reset() {
+	*x = CustomWordsResponse{}
+	mi := &file_proto_privutil_proto_msgTypes[155]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CustomWordsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CustomWordsResponse) ProtoMessage() {}
+
+func (x *CustomWordsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_privutil_proto_msgTypes[155]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CustomWordsResponse.ProtoReflect.Descriptor instead.
+func (*CustomWordsResponse) Descriptor() ([]byte, []int) {
+	return file_proto_privutil_proto_rawDescGZIP(), []int{155}
+}
+
+func (x *CustomWordsResponse) GetWords() []string {
+	if x != nil {
+		return x.Words
+	}
+	return nil
+}
+
+func (x *CustomWordsResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 var File_proto_privutil_proto protoreflect.FileDescriptor
 
 const file_proto_privutil_proto_rawDesc = "" +
@@ -10524,7 +10702,15 @@ const file_proto_privutil_proto_rawDesc = "" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x14\n" +
 	"\x05label\x18\x02 \x01(\tR\x05label\"O\n" +
 	"\x16SpellLanguagesResponse\x125\n" +
-	"\tlanguages\x18\x01 \x03(\v2\x17.privutil.SpellLanguageR\tlanguages*<\n" +
+	"\tlanguages\x18\x01 \x03(\v2\x17.privutil.SpellLanguageR\tlanguages\"\x17\n" +
+	"\x15GetCustomWordsRequest\"-\n" +
+	"\x15AddCustomWordsRequest\x12\x14\n" +
+	"\x05words\x18\x01 \x03(\tR\x05words\"-\n" +
+	"\x17RemoveCustomWordRequest\x12\x12\n" +
+	"\x04word\x18\x01 \x01(\tR\x04word\"A\n" +
+	"\x13CustomWordsResponse\x12\x14\n" +
+	"\x05words\x18\x01 \x03(\tR\x05words\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error*<\n" +
 	"\n" +
 	"DataFormat\x12\b\n" +
 	"\x04JSON\x10\x00\x12\b\n" +
@@ -10571,7 +10757,7 @@ const file_proto_privutil_proto_rawDesc = "" +
 	"\tUNIT_AREA\x10\x03\x12\x0f\n" +
 	"\vUNIT_VOLUME\x10\x04\x12\x0e\n" +
 	"\n" +
-	"UNIT_SPEED\x10\x052\xc0)\n" +
+	"UNIT_SPEED\x10\x052\xc0+\n" +
 	"\x0fPrivUtilService\x127\n" +
 	"\x04Diff\x12\x15.privutil.DiffRequest\x1a\x16.privutil.DiffResponse\"\x00\x12C\n" +
 	"\fBase64Encode\x12\x17.privutil.Base64Request\x1a\x18.privutil.Base64Response\"\x00\x12C\n" +
@@ -10654,7 +10840,10 @@ const file_proto_privutil_proto_rawDesc = "" +
 	"TokenCount\x12\x1b.privutil.TokenCountRequest\x1a\x1c.privutil.TokenCountResponse\"\x00\x12I\n" +
 	"\n" +
 	"SpellCheck\x12\x1b.privutil.SpellCheckRequest\x1a\x1c.privutil.SpellCheckResponse\"\x00\x12U\n" +
-	"\x0eSpellLanguages\x12\x1f.privutil.SpellLanguagesRequest\x1a .privutil.SpellLanguagesResponse\"\x00B'Z%github.com/odinnordico/privutil/protob\x06proto3"
+	"\x0eSpellLanguages\x12\x1f.privutil.SpellLanguagesRequest\x1a .privutil.SpellLanguagesResponse\"\x00\x12R\n" +
+	"\x0eGetCustomWords\x12\x1f.privutil.GetCustomWordsRequest\x1a\x1d.privutil.CustomWordsResponse\"\x00\x12R\n" +
+	"\x0eAddCustomWords\x12\x1f.privutil.AddCustomWordsRequest\x1a\x1d.privutil.CustomWordsResponse\"\x00\x12V\n" +
+	"\x10RemoveCustomWord\x12!.privutil.RemoveCustomWordRequest\x1a\x1d.privutil.CustomWordsResponse\"\x00B'Z%github.com/odinnordico/privutil/protob\x06proto3"
 
 var (
 	file_proto_privutil_proto_rawDescOnce sync.Once
@@ -10669,7 +10858,7 @@ func file_proto_privutil_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_privutil_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_proto_privutil_proto_msgTypes = make([]protoimpl.MessageInfo, 152)
+var file_proto_privutil_proto_msgTypes = make([]protoimpl.MessageInfo, 156)
 var file_proto_privutil_proto_goTypes = []any{
 	(DataFormat)(0),                    // 0: privutil.DataFormat
 	(TextAction)(0),                    // 1: privutil.TextAction
@@ -10828,6 +11017,10 @@ var file_proto_privutil_proto_goTypes = []any{
 	(*SpellLanguagesRequest)(nil),      // 154: privutil.SpellLanguagesRequest
 	(*SpellLanguage)(nil),              // 155: privutil.SpellLanguage
 	(*SpellLanguagesResponse)(nil),     // 156: privutil.SpellLanguagesResponse
+	(*GetCustomWordsRequest)(nil),      // 157: privutil.GetCustomWordsRequest
+	(*AddCustomWordsRequest)(nil),      // 158: privutil.AddCustomWordsRequest
+	(*RemoveCustomWordRequest)(nil),    // 159: privutil.RemoveCustomWordRequest
+	(*CustomWordsResponse)(nil),        // 160: privutil.CustomWordsResponse
 }
 var file_proto_privutil_proto_depIdxs = []int32{
 	0,   // 0: privutil.ConvertRequest.source_format:type_name -> privutil.DataFormat
@@ -10927,82 +11120,88 @@ var file_proto_privutil_proto_depIdxs = []int32{
 	148, // 94: privutil.PrivUtilService.TokenCount:input_type -> privutil.TokenCountRequest
 	151, // 95: privutil.PrivUtilService.SpellCheck:input_type -> privutil.SpellCheckRequest
 	154, // 96: privutil.PrivUtilService.SpellLanguages:input_type -> privutil.SpellLanguagesRequest
-	6,   // 97: privutil.PrivUtilService.Diff:output_type -> privutil.DiffResponse
-	8,   // 98: privutil.PrivUtilService.Base64Encode:output_type -> privutil.Base64Response
-	8,   // 99: privutil.PrivUtilService.Base64Decode:output_type -> privutil.Base64Response
-	10,  // 100: privutil.PrivUtilService.JsonFormat:output_type -> privutil.JsonFormatResponse
-	12,  // 101: privutil.PrivUtilService.Convert:output_type -> privutil.ConvertResponse
-	14,  // 102: privutil.PrivUtilService.ValidateData:output_type -> privutil.ValidateResponse
-	16,  // 103: privutil.PrivUtilService.GenerateUuid:output_type -> privutil.UuidResponse
-	18,  // 104: privutil.PrivUtilService.GenerateLorem:output_type -> privutil.LoremResponse
-	20,  // 105: privutil.PrivUtilService.CalculateHash:output_type -> privutil.HashResponse
-	48,  // 106: privutil.PrivUtilService.TextInspect:output_type -> privutil.TextInspectResponse
-	50,  // 107: privutil.PrivUtilService.TextManipulate:output_type -> privutil.TextManipulateResponse
-	22,  // 108: privutil.PrivUtilService.UrlEncode:output_type -> privutil.TextResponse
-	22,  // 109: privutil.PrivUtilService.UrlDecode:output_type -> privutil.TextResponse
-	22,  // 110: privutil.PrivUtilService.HtmlEncode:output_type -> privutil.TextResponse
-	22,  // 111: privutil.PrivUtilService.HtmlDecode:output_type -> privutil.TextResponse
-	24,  // 112: privutil.PrivUtilService.TimeConvert:output_type -> privutil.TimeResponse
-	26,  // 113: privutil.PrivUtilService.JwtDecode:output_type -> privutil.JwtResponse
-	28,  // 114: privutil.PrivUtilService.RegexTest:output_type -> privutil.RegexResponse
-	30,  // 115: privutil.PrivUtilService.JsonToGo:output_type -> privutil.JsonToGoResponse
-	32,  // 116: privutil.PrivUtilService.CronExplain:output_type -> privutil.CronResponse
-	34,  // 117: privutil.PrivUtilService.CertParse:output_type -> privutil.CertResponse
-	36,  // 118: privutil.PrivUtilService.ColorConvert:output_type -> privutil.ColorResponse
-	38,  // 119: privutil.PrivUtilService.CaseConvert:output_type -> privutil.CaseResponse
-	40,  // 120: privutil.PrivUtilService.StringEscape:output_type -> privutil.EscapeResponse
-	42,  // 121: privutil.PrivUtilService.TextSimilarity:output_type -> privutil.SimilarityResponse
-	44,  // 122: privutil.PrivUtilService.SqlFormat:output_type -> privutil.SqlResponse
-	46,  // 123: privutil.PrivUtilService.IpCalc:output_type -> privutil.IpResponse
-	52,  // 124: privutil.PrivUtilService.GeneratePassword:output_type -> privutil.PasswordResponse
-	54,  // 125: privutil.PrivUtilService.GenerateRsaKeyPair:output_type -> privutil.RsaKeyResponse
-	56,  // 126: privutil.PrivUtilService.BaseConvert:output_type -> privutil.BaseConvertResponse
-	22,  // 127: privutil.PrivUtilService.MarkdownToHtml:output_type -> privutil.TextResponse
-	22,  // 128: privutil.PrivUtilService.HtmlToMarkdown:output_type -> privutil.TextResponse
-	68,  // 129: privutil.PrivUtilService.HmacGenerate:output_type -> privutil.HmacResponse
-	70,  // 130: privutil.PrivUtilService.OtpGenerate:output_type -> privutil.OtpResponse
-	72,  // 131: privutil.PrivUtilService.OtpValidate:output_type -> privutil.OtpValidateResponse
-	74,  // 132: privutil.PrivUtilService.UlidGenerate:output_type -> privutil.UlidResponse
-	76,  // 133: privutil.PrivUtilService.CaesarCipher:output_type -> privutil.CaesarResponse
-	78,  // 134: privutil.PrivUtilService.TextEncode:output_type -> privutil.TextEncodeResponse
-	80,  // 135: privutil.PrivUtilService.MorseCode:output_type -> privutil.MorseResponse
-	82,  // 136: privutil.PrivUtilService.BasicAuthGenerate:output_type -> privutil.BasicAuthResponse
-	58,  // 137: privutil.PrivUtilService.ChmodCalc:output_type -> privutil.ChmodResponse
-	60,  // 138: privutil.PrivUtilService.Ipv4Convert:output_type -> privutil.Ipv4ConvertResponse
-	62,  // 139: privutil.PrivUtilService.Ipv4RangeExpand:output_type -> privutil.Ipv4RangeResponse
-	64,  // 140: privutil.PrivUtilService.GeneratePort:output_type -> privutil.PortResponse
-	66,  // 141: privutil.PrivUtilService.GenerateMac:output_type -> privutil.MacResponse
-	84,  // 142: privutil.PrivUtilService.Slugify:output_type -> privutil.SlugifyResponse
-	87,  // 143: privutil.PrivUtilService.HiddenChars:output_type -> privutil.HiddenCharsResponse
-	89,  // 144: privutil.PrivUtilService.TextReplace:output_type -> privutil.TextReplaceResponse
-	91,  // 145: privutil.PrivUtilService.StringObfuscate:output_type -> privutil.StringObfuscateResponse
-	93,  // 146: privutil.PrivUtilService.NumeronymGenerate:output_type -> privutil.NumeronymResponse
-	95,  // 147: privutil.PrivUtilService.NatoAlphabet:output_type -> privutil.NatoResponse
-	98,  // 148: privutil.PrivUtilService.ListProcess:output_type -> privutil.ListResponse
-	101, // 149: privutil.PrivUtilService.MathEval:output_type -> privutil.MathEvalResponse
-	103, // 150: privutil.PrivUtilService.PercentageCalc:output_type -> privutil.PercentageResponse
-	105, // 151: privutil.PrivUtilService.TempConvert:output_type -> privutil.TempConvertResponse
-	108, // 152: privutil.PrivUtilService.UnitConvert:output_type -> privutil.UnitConvertResponse
-	110, // 153: privutil.PrivUtilService.DateDiff:output_type -> privutil.DateDiffResponse
-	113, // 154: privutil.PrivUtilService.LeapYear:output_type -> privutil.LeapYearResponse
-	115, // 155: privutil.PrivUtilService.DateAdd:output_type -> privutil.DateAddResponse
-	118, // 156: privutil.PrivUtilService.DateFormat:output_type -> privutil.DateFormatResponse
-	120, // 157: privutil.PrivUtilService.DateInfo:output_type -> privutil.DateInfoResponse
-	123, // 158: privutil.PrivUtilService.UrlParse:output_type -> privutil.UrlParseResponse
-	126, // 159: privutil.PrivUtilService.UserAgentParse:output_type -> privutil.UserAgentParseResponse
-	129, // 160: privutil.PrivUtilService.HttpStatusSearch:output_type -> privutil.HttpStatusSearchResponse
-	132, // 161: privutil.PrivUtilService.MimeLookup:output_type -> privutil.MimeLookupResponse
-	134, // 162: privutil.PrivUtilService.DockerRunToCompose:output_type -> privutil.DockerRunToComposeResponse
-	138, // 163: privutil.PrivUtilService.GitCheatSheet:output_type -> privutil.GitCheatSheetResponse
-	140, // 164: privutil.PrivUtilService.SvgOptimize:output_type -> privutil.SvgOptimizeResponse
-	143, // 165: privutil.PrivUtilService.ExifRead:output_type -> privutil.ExifReadResponse
-	145, // 166: privutil.PrivUtilService.FileToBase64:output_type -> privutil.FileToBase64Response
-	147, // 167: privutil.PrivUtilService.Base64ToFile:output_type -> privutil.Base64ToFileResponse
-	150, // 168: privutil.PrivUtilService.TokenCount:output_type -> privutil.TokenCountResponse
-	153, // 169: privutil.PrivUtilService.SpellCheck:output_type -> privutil.SpellCheckResponse
-	156, // 170: privutil.PrivUtilService.SpellLanguages:output_type -> privutil.SpellLanguagesResponse
-	97,  // [97:171] is the sub-list for method output_type
-	23,  // [23:97] is the sub-list for method input_type
+	157, // 97: privutil.PrivUtilService.GetCustomWords:input_type -> privutil.GetCustomWordsRequest
+	158, // 98: privutil.PrivUtilService.AddCustomWords:input_type -> privutil.AddCustomWordsRequest
+	159, // 99: privutil.PrivUtilService.RemoveCustomWord:input_type -> privutil.RemoveCustomWordRequest
+	6,   // 100: privutil.PrivUtilService.Diff:output_type -> privutil.DiffResponse
+	8,   // 101: privutil.PrivUtilService.Base64Encode:output_type -> privutil.Base64Response
+	8,   // 102: privutil.PrivUtilService.Base64Decode:output_type -> privutil.Base64Response
+	10,  // 103: privutil.PrivUtilService.JsonFormat:output_type -> privutil.JsonFormatResponse
+	12,  // 104: privutil.PrivUtilService.Convert:output_type -> privutil.ConvertResponse
+	14,  // 105: privutil.PrivUtilService.ValidateData:output_type -> privutil.ValidateResponse
+	16,  // 106: privutil.PrivUtilService.GenerateUuid:output_type -> privutil.UuidResponse
+	18,  // 107: privutil.PrivUtilService.GenerateLorem:output_type -> privutil.LoremResponse
+	20,  // 108: privutil.PrivUtilService.CalculateHash:output_type -> privutil.HashResponse
+	48,  // 109: privutil.PrivUtilService.TextInspect:output_type -> privutil.TextInspectResponse
+	50,  // 110: privutil.PrivUtilService.TextManipulate:output_type -> privutil.TextManipulateResponse
+	22,  // 111: privutil.PrivUtilService.UrlEncode:output_type -> privutil.TextResponse
+	22,  // 112: privutil.PrivUtilService.UrlDecode:output_type -> privutil.TextResponse
+	22,  // 113: privutil.PrivUtilService.HtmlEncode:output_type -> privutil.TextResponse
+	22,  // 114: privutil.PrivUtilService.HtmlDecode:output_type -> privutil.TextResponse
+	24,  // 115: privutil.PrivUtilService.TimeConvert:output_type -> privutil.TimeResponse
+	26,  // 116: privutil.PrivUtilService.JwtDecode:output_type -> privutil.JwtResponse
+	28,  // 117: privutil.PrivUtilService.RegexTest:output_type -> privutil.RegexResponse
+	30,  // 118: privutil.PrivUtilService.JsonToGo:output_type -> privutil.JsonToGoResponse
+	32,  // 119: privutil.PrivUtilService.CronExplain:output_type -> privutil.CronResponse
+	34,  // 120: privutil.PrivUtilService.CertParse:output_type -> privutil.CertResponse
+	36,  // 121: privutil.PrivUtilService.ColorConvert:output_type -> privutil.ColorResponse
+	38,  // 122: privutil.PrivUtilService.CaseConvert:output_type -> privutil.CaseResponse
+	40,  // 123: privutil.PrivUtilService.StringEscape:output_type -> privutil.EscapeResponse
+	42,  // 124: privutil.PrivUtilService.TextSimilarity:output_type -> privutil.SimilarityResponse
+	44,  // 125: privutil.PrivUtilService.SqlFormat:output_type -> privutil.SqlResponse
+	46,  // 126: privutil.PrivUtilService.IpCalc:output_type -> privutil.IpResponse
+	52,  // 127: privutil.PrivUtilService.GeneratePassword:output_type -> privutil.PasswordResponse
+	54,  // 128: privutil.PrivUtilService.GenerateRsaKeyPair:output_type -> privutil.RsaKeyResponse
+	56,  // 129: privutil.PrivUtilService.BaseConvert:output_type -> privutil.BaseConvertResponse
+	22,  // 130: privutil.PrivUtilService.MarkdownToHtml:output_type -> privutil.TextResponse
+	22,  // 131: privutil.PrivUtilService.HtmlToMarkdown:output_type -> privutil.TextResponse
+	68,  // 132: privutil.PrivUtilService.HmacGenerate:output_type -> privutil.HmacResponse
+	70,  // 133: privutil.PrivUtilService.OtpGenerate:output_type -> privutil.OtpResponse
+	72,  // 134: privutil.PrivUtilService.OtpValidate:output_type -> privutil.OtpValidateResponse
+	74,  // 135: privutil.PrivUtilService.UlidGenerate:output_type -> privutil.UlidResponse
+	76,  // 136: privutil.PrivUtilService.CaesarCipher:output_type -> privutil.CaesarResponse
+	78,  // 137: privutil.PrivUtilService.TextEncode:output_type -> privutil.TextEncodeResponse
+	80,  // 138: privutil.PrivUtilService.MorseCode:output_type -> privutil.MorseResponse
+	82,  // 139: privutil.PrivUtilService.BasicAuthGenerate:output_type -> privutil.BasicAuthResponse
+	58,  // 140: privutil.PrivUtilService.ChmodCalc:output_type -> privutil.ChmodResponse
+	60,  // 141: privutil.PrivUtilService.Ipv4Convert:output_type -> privutil.Ipv4ConvertResponse
+	62,  // 142: privutil.PrivUtilService.Ipv4RangeExpand:output_type -> privutil.Ipv4RangeResponse
+	64,  // 143: privutil.PrivUtilService.GeneratePort:output_type -> privutil.PortResponse
+	66,  // 144: privutil.PrivUtilService.GenerateMac:output_type -> privutil.MacResponse
+	84,  // 145: privutil.PrivUtilService.Slugify:output_type -> privutil.SlugifyResponse
+	87,  // 146: privutil.PrivUtilService.HiddenChars:output_type -> privutil.HiddenCharsResponse
+	89,  // 147: privutil.PrivUtilService.TextReplace:output_type -> privutil.TextReplaceResponse
+	91,  // 148: privutil.PrivUtilService.StringObfuscate:output_type -> privutil.StringObfuscateResponse
+	93,  // 149: privutil.PrivUtilService.NumeronymGenerate:output_type -> privutil.NumeronymResponse
+	95,  // 150: privutil.PrivUtilService.NatoAlphabet:output_type -> privutil.NatoResponse
+	98,  // 151: privutil.PrivUtilService.ListProcess:output_type -> privutil.ListResponse
+	101, // 152: privutil.PrivUtilService.MathEval:output_type -> privutil.MathEvalResponse
+	103, // 153: privutil.PrivUtilService.PercentageCalc:output_type -> privutil.PercentageResponse
+	105, // 154: privutil.PrivUtilService.TempConvert:output_type -> privutil.TempConvertResponse
+	108, // 155: privutil.PrivUtilService.UnitConvert:output_type -> privutil.UnitConvertResponse
+	110, // 156: privutil.PrivUtilService.DateDiff:output_type -> privutil.DateDiffResponse
+	113, // 157: privutil.PrivUtilService.LeapYear:output_type -> privutil.LeapYearResponse
+	115, // 158: privutil.PrivUtilService.DateAdd:output_type -> privutil.DateAddResponse
+	118, // 159: privutil.PrivUtilService.DateFormat:output_type -> privutil.DateFormatResponse
+	120, // 160: privutil.PrivUtilService.DateInfo:output_type -> privutil.DateInfoResponse
+	123, // 161: privutil.PrivUtilService.UrlParse:output_type -> privutil.UrlParseResponse
+	126, // 162: privutil.PrivUtilService.UserAgentParse:output_type -> privutil.UserAgentParseResponse
+	129, // 163: privutil.PrivUtilService.HttpStatusSearch:output_type -> privutil.HttpStatusSearchResponse
+	132, // 164: privutil.PrivUtilService.MimeLookup:output_type -> privutil.MimeLookupResponse
+	134, // 165: privutil.PrivUtilService.DockerRunToCompose:output_type -> privutil.DockerRunToComposeResponse
+	138, // 166: privutil.PrivUtilService.GitCheatSheet:output_type -> privutil.GitCheatSheetResponse
+	140, // 167: privutil.PrivUtilService.SvgOptimize:output_type -> privutil.SvgOptimizeResponse
+	143, // 168: privutil.PrivUtilService.ExifRead:output_type -> privutil.ExifReadResponse
+	145, // 169: privutil.PrivUtilService.FileToBase64:output_type -> privutil.FileToBase64Response
+	147, // 170: privutil.PrivUtilService.Base64ToFile:output_type -> privutil.Base64ToFileResponse
+	150, // 171: privutil.PrivUtilService.TokenCount:output_type -> privutil.TokenCountResponse
+	153, // 172: privutil.PrivUtilService.SpellCheck:output_type -> privutil.SpellCheckResponse
+	156, // 173: privutil.PrivUtilService.SpellLanguages:output_type -> privutil.SpellLanguagesResponse
+	160, // 174: privutil.PrivUtilService.GetCustomWords:output_type -> privutil.CustomWordsResponse
+	160, // 175: privutil.PrivUtilService.AddCustomWords:output_type -> privutil.CustomWordsResponse
+	160, // 176: privutil.PrivUtilService.RemoveCustomWord:output_type -> privutil.CustomWordsResponse
+	100, // [100:177] is the sub-list for method output_type
+	23,  // [23:100] is the sub-list for method input_type
 	23,  // [23:23] is the sub-list for extension type_name
 	23,  // [23:23] is the sub-list for extension extendee
 	0,   // [0:23] is the sub-list for field type_name
@@ -11020,7 +11219,7 @@ func file_proto_privutil_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_privutil_proto_rawDesc), len(file_proto_privutil_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   152,
+			NumMessages:   156,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/privutil.proto
+++ b/proto/privutil.proto
@@ -79,6 +79,9 @@ service PrivUtilService {
   rpc TokenCount(TokenCountRequest) returns (TokenCountResponse) {}
   rpc SpellCheck(SpellCheckRequest) returns (SpellCheckResponse) {}
   rpc SpellLanguages(SpellLanguagesRequest) returns (SpellLanguagesResponse) {}
+  rpc GetCustomWords(GetCustomWordsRequest) returns (CustomWordsResponse) {}
+  rpc AddCustomWords(AddCustomWordsRequest) returns (CustomWordsResponse) {}
+  rpc RemoveCustomWord(RemoveCustomWordRequest) returns (CustomWordsResponse) {}
 }
 
 message DiffRequest {
@@ -1075,4 +1078,18 @@ message SpellLanguage {
 }
 message SpellLanguagesResponse {
   repeated SpellLanguage languages = 1;
+}
+
+// Custom dictionary: a server-side, persisted list of extra accepted words,
+// shared across all languages. SpellCheck consults it automatically.
+message GetCustomWordsRequest {}
+message AddCustomWordsRequest {
+  repeated string words = 1; // words to add (whitespace/case normalized server-side)
+}
+message RemoveCustomWordRequest {
+  string word = 1;
+}
+message CustomWordsResponse {
+  repeated string words = 1; // the full custom word list after the operation, sorted
+  string          error = 2;
 }

--- a/proto/protoconnect/privutil.connect.go
+++ b/proto/protoconnect/privutil.connect.go
@@ -250,6 +250,15 @@ const (
 	// PrivUtilServiceSpellLanguagesProcedure is the fully-qualified name of the PrivUtilService's
 	// SpellLanguages RPC.
 	PrivUtilServiceSpellLanguagesProcedure = "/privutil.PrivUtilService/SpellLanguages"
+	// PrivUtilServiceGetCustomWordsProcedure is the fully-qualified name of the PrivUtilService's
+	// GetCustomWords RPC.
+	PrivUtilServiceGetCustomWordsProcedure = "/privutil.PrivUtilService/GetCustomWords"
+	// PrivUtilServiceAddCustomWordsProcedure is the fully-qualified name of the PrivUtilService's
+	// AddCustomWords RPC.
+	PrivUtilServiceAddCustomWordsProcedure = "/privutil.PrivUtilService/AddCustomWords"
+	// PrivUtilServiceRemoveCustomWordProcedure is the fully-qualified name of the PrivUtilService's
+	// RemoveCustomWord RPC.
+	PrivUtilServiceRemoveCustomWordProcedure = "/privutil.PrivUtilService/RemoveCustomWord"
 )
 
 // PrivUtilServiceClient is a client for the privutil.PrivUtilService service.
@@ -328,6 +337,9 @@ type PrivUtilServiceClient interface {
 	TokenCount(context.Context, *connect.Request[proto.TokenCountRequest]) (*connect.Response[proto.TokenCountResponse], error)
 	SpellCheck(context.Context, *connect.Request[proto.SpellCheckRequest]) (*connect.Response[proto.SpellCheckResponse], error)
 	SpellLanguages(context.Context, *connect.Request[proto.SpellLanguagesRequest]) (*connect.Response[proto.SpellLanguagesResponse], error)
+	GetCustomWords(context.Context, *connect.Request[proto.GetCustomWordsRequest]) (*connect.Response[proto.CustomWordsResponse], error)
+	AddCustomWords(context.Context, *connect.Request[proto.AddCustomWordsRequest]) (*connect.Response[proto.CustomWordsResponse], error)
+	RemoveCustomWord(context.Context, *connect.Request[proto.RemoveCustomWordRequest]) (*connect.Response[proto.CustomWordsResponse], error)
 }
 
 // NewPrivUtilServiceClient constructs a client for the privutil.PrivUtilService service. By
@@ -785,6 +797,24 @@ func NewPrivUtilServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 			connect.WithSchema(privUtilServiceMethods.ByName("SpellLanguages")),
 			connect.WithClientOptions(opts...),
 		),
+		getCustomWords: connect.NewClient[proto.GetCustomWordsRequest, proto.CustomWordsResponse](
+			httpClient,
+			baseURL+PrivUtilServiceGetCustomWordsProcedure,
+			connect.WithSchema(privUtilServiceMethods.ByName("GetCustomWords")),
+			connect.WithClientOptions(opts...),
+		),
+		addCustomWords: connect.NewClient[proto.AddCustomWordsRequest, proto.CustomWordsResponse](
+			httpClient,
+			baseURL+PrivUtilServiceAddCustomWordsProcedure,
+			connect.WithSchema(privUtilServiceMethods.ByName("AddCustomWords")),
+			connect.WithClientOptions(opts...),
+		),
+		removeCustomWord: connect.NewClient[proto.RemoveCustomWordRequest, proto.CustomWordsResponse](
+			httpClient,
+			baseURL+PrivUtilServiceRemoveCustomWordProcedure,
+			connect.WithSchema(privUtilServiceMethods.ByName("RemoveCustomWord")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -864,6 +894,9 @@ type privUtilServiceClient struct {
 	tokenCount         *connect.Client[proto.TokenCountRequest, proto.TokenCountResponse]
 	spellCheck         *connect.Client[proto.SpellCheckRequest, proto.SpellCheckResponse]
 	spellLanguages     *connect.Client[proto.SpellLanguagesRequest, proto.SpellLanguagesResponse]
+	getCustomWords     *connect.Client[proto.GetCustomWordsRequest, proto.CustomWordsResponse]
+	addCustomWords     *connect.Client[proto.AddCustomWordsRequest, proto.CustomWordsResponse]
+	removeCustomWord   *connect.Client[proto.RemoveCustomWordRequest, proto.CustomWordsResponse]
 }
 
 // Diff calls privutil.PrivUtilService.Diff.
@@ -1236,6 +1269,21 @@ func (c *privUtilServiceClient) SpellLanguages(ctx context.Context, req *connect
 	return c.spellLanguages.CallUnary(ctx, req)
 }
 
+// GetCustomWords calls privutil.PrivUtilService.GetCustomWords.
+func (c *privUtilServiceClient) GetCustomWords(ctx context.Context, req *connect.Request[proto.GetCustomWordsRequest]) (*connect.Response[proto.CustomWordsResponse], error) {
+	return c.getCustomWords.CallUnary(ctx, req)
+}
+
+// AddCustomWords calls privutil.PrivUtilService.AddCustomWords.
+func (c *privUtilServiceClient) AddCustomWords(ctx context.Context, req *connect.Request[proto.AddCustomWordsRequest]) (*connect.Response[proto.CustomWordsResponse], error) {
+	return c.addCustomWords.CallUnary(ctx, req)
+}
+
+// RemoveCustomWord calls privutil.PrivUtilService.RemoveCustomWord.
+func (c *privUtilServiceClient) RemoveCustomWord(ctx context.Context, req *connect.Request[proto.RemoveCustomWordRequest]) (*connect.Response[proto.CustomWordsResponse], error) {
+	return c.removeCustomWord.CallUnary(ctx, req)
+}
+
 // PrivUtilServiceHandler is an implementation of the privutil.PrivUtilService service.
 type PrivUtilServiceHandler interface {
 	Diff(context.Context, *connect.Request[proto.DiffRequest]) (*connect.Response[proto.DiffResponse], error)
@@ -1312,6 +1360,9 @@ type PrivUtilServiceHandler interface {
 	TokenCount(context.Context, *connect.Request[proto.TokenCountRequest]) (*connect.Response[proto.TokenCountResponse], error)
 	SpellCheck(context.Context, *connect.Request[proto.SpellCheckRequest]) (*connect.Response[proto.SpellCheckResponse], error)
 	SpellLanguages(context.Context, *connect.Request[proto.SpellLanguagesRequest]) (*connect.Response[proto.SpellLanguagesResponse], error)
+	GetCustomWords(context.Context, *connect.Request[proto.GetCustomWordsRequest]) (*connect.Response[proto.CustomWordsResponse], error)
+	AddCustomWords(context.Context, *connect.Request[proto.AddCustomWordsRequest]) (*connect.Response[proto.CustomWordsResponse], error)
+	RemoveCustomWord(context.Context, *connect.Request[proto.RemoveCustomWordRequest]) (*connect.Response[proto.CustomWordsResponse], error)
 }
 
 // NewPrivUtilServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -1765,6 +1816,24 @@ func NewPrivUtilServiceHandler(svc PrivUtilServiceHandler, opts ...connect.Handl
 		connect.WithSchema(privUtilServiceMethods.ByName("SpellLanguages")),
 		connect.WithHandlerOptions(opts...),
 	)
+	privUtilServiceGetCustomWordsHandler := connect.NewUnaryHandler(
+		PrivUtilServiceGetCustomWordsProcedure,
+		svc.GetCustomWords,
+		connect.WithSchema(privUtilServiceMethods.ByName("GetCustomWords")),
+		connect.WithHandlerOptions(opts...),
+	)
+	privUtilServiceAddCustomWordsHandler := connect.NewUnaryHandler(
+		PrivUtilServiceAddCustomWordsProcedure,
+		svc.AddCustomWords,
+		connect.WithSchema(privUtilServiceMethods.ByName("AddCustomWords")),
+		connect.WithHandlerOptions(opts...),
+	)
+	privUtilServiceRemoveCustomWordHandler := connect.NewUnaryHandler(
+		PrivUtilServiceRemoveCustomWordProcedure,
+		svc.RemoveCustomWord,
+		connect.WithSchema(privUtilServiceMethods.ByName("RemoveCustomWord")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/privutil.PrivUtilService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case PrivUtilServiceDiffProcedure:
@@ -1915,6 +1984,12 @@ func NewPrivUtilServiceHandler(svc PrivUtilServiceHandler, opts ...connect.Handl
 			privUtilServiceSpellCheckHandler.ServeHTTP(w, r)
 		case PrivUtilServiceSpellLanguagesProcedure:
 			privUtilServiceSpellLanguagesHandler.ServeHTTP(w, r)
+		case PrivUtilServiceGetCustomWordsProcedure:
+			privUtilServiceGetCustomWordsHandler.ServeHTTP(w, r)
+		case PrivUtilServiceAddCustomWordsProcedure:
+			privUtilServiceAddCustomWordsHandler.ServeHTTP(w, r)
+		case PrivUtilServiceRemoveCustomWordProcedure:
+			privUtilServiceRemoveCustomWordHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -2218,4 +2293,16 @@ func (UnimplementedPrivUtilServiceHandler) SpellCheck(context.Context, *connect.
 
 func (UnimplementedPrivUtilServiceHandler) SpellLanguages(context.Context, *connect.Request[proto.SpellLanguagesRequest]) (*connect.Response[proto.SpellLanguagesResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("privutil.PrivUtilService.SpellLanguages is not implemented"))
+}
+
+func (UnimplementedPrivUtilServiceHandler) GetCustomWords(context.Context, *connect.Request[proto.GetCustomWordsRequest]) (*connect.Response[proto.CustomWordsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("privutil.PrivUtilService.GetCustomWords is not implemented"))
+}
+
+func (UnimplementedPrivUtilServiceHandler) AddCustomWords(context.Context, *connect.Request[proto.AddCustomWordsRequest]) (*connect.Response[proto.CustomWordsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("privutil.PrivUtilService.AddCustomWords is not implemented"))
+}
+
+func (UnimplementedPrivUtilServiceHandler) RemoveCustomWord(context.Context, *connect.Request[proto.RemoveCustomWordRequest]) (*connect.Response[proto.CustomWordsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("privutil.PrivUtilService.RemoveCustomWord is not implemented"))
 }

--- a/web/src/components/SpellCheckTool.tsx
+++ b/web/src/components/SpellCheckTool.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { client } from '../lib/client';
-import { Copy, Check, Wand2, Eye, X, CheckCircle2 } from 'lucide-react';
+import { Copy, Check, Wand2, Eye, X, CheckCircle2, BookPlus, Book, Plus, ChevronDown, ChevronUp } from 'lucide-react';
 import { cn } from '../lib/utils';
 import type { SpellIssue, SpellLanguage } from '../proto/proto/privutil';
 
@@ -102,6 +102,10 @@ export function SpellCheckTool() {
   const [error, setError] = useState('');
   const [popover, setPopover] = useState<PopoverState | null>(null);
   const [copied, setCopied] = useState(false);
+  const [customWords, setCustomWords] = useState<string[]>([]);
+  const [dictOpen, setDictOpen] = useState(false);
+  const [newWord, setNewWord] = useState('');
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const spanRefs = useRef<Record<string, HTMLSpanElement | null>>({});
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -111,6 +115,11 @@ export function SpellCheckTool() {
     client.spellLanguages({}).then(resp => {
       if (resp.languages.length > 0) setLanguages(resp.languages);
     }).catch(() => { /* keep static fallback */ });
+  }, []);
+
+  // Load the server-side custom dictionary on mount.
+  useEffect(() => {
+    client.getCustomWords({}).then(resp => setCustomWords(resp.words)).catch(() => { /* ignore */ });
   }, []);
 
   // Debounced check whenever text or language changes.
@@ -134,7 +143,7 @@ export function SpellCheckTool() {
       }
     }, DEBOUNCE_MS);
     return () => clearTimeout(timer);
-  }, [text, language]);
+  }, [text, language, refreshKey]);
 
   const visibleIssues = useMemo(
     () => issues.filter(is => !ignored.has(signature(is))),
@@ -189,6 +198,32 @@ export function SpellCheckTool() {
   const ignoreIssue = useCallback((is: SpellIssue) => {
     setIgnored(prev => new Set(prev).add(signature(is)));
     setPopover(null);
+  }, []);
+
+  const addToDictionary = useCallback(async (word: string) => {
+    const w = word.trim();
+    if (!w) return;
+    try {
+      const resp = await client.addCustomWords({ words: [w] } as Parameters<typeof client.addCustomWords>[0]);
+      if (resp.error) { setError(resp.error); return; }
+      setCustomWords(resp.words);
+      setNewWord('');
+      setPopover(null);
+      setRefreshKey(k => k + 1); // re-check so the word stops being flagged
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to add word to dictionary');
+    }
+  }, []);
+
+  const removeFromDictionary = useCallback(async (word: string) => {
+    try {
+      const resp = await client.removeCustomWord({ word } as Parameters<typeof client.removeCustomWord>[0]);
+      if (resp.error) { setError(resp.error); return; }
+      setCustomWords(resp.words);
+      setRefreshKey(k => k + 1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to remove word from dictionary');
+    }
   }, []);
 
   const focusIssue = useCallback((id: string) => {
@@ -360,9 +395,76 @@ export function SpellCheckTool() {
                         ))}
                       </div>
                     )}
+                    {is.type === 'spelling' && (
+                      <button
+                        onClick={() => addToDictionary(is.text)}
+                        className="flex items-center gap-1 text-xs font-medium text-slate-400 hover:text-kawa-600 dark:hover:text-kawa-400 transition-colors"
+                      >
+                        <BookPlus className="w-3.5 h-3.5" /> Add to dictionary
+                      </button>
+                    )}
                   </div>
                 );
               })
+            )}
+          </div>
+
+          {/* Custom dictionary manager */}
+          <div className="bg-white dark:bg-neutral-800 rounded-lg border border-slate-200 dark:border-neutral-700 shadow-sm">
+            <button
+              onClick={() => setDictOpen(o => !o)}
+              className="w-full flex items-center justify-between p-3 text-sm font-bold text-slate-600 dark:text-slate-300"
+            >
+              <span className="flex items-center gap-1.5">
+                <Book className="w-4 h-4" /> Custom dictionary
+                <span className="font-normal text-slate-400 dark:text-slate-500">({customWords.length})</span>
+              </span>
+              {dictOpen ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+            </button>
+            {dictOpen && (
+              <div className="p-3 pt-0 space-y-3">
+                <form
+                  onSubmit={e => { e.preventDefault(); addToDictionary(newWord); }}
+                  className="flex gap-2"
+                >
+                  <input
+                    value={newWord}
+                    onChange={e => setNewWord(e.target.value)}
+                    placeholder="Add a word…"
+                    className="flex-1 min-w-0 bg-slate-50 dark:bg-neutral-900 border border-slate-300 dark:border-neutral-700 rounded-md px-2 py-1 text-sm text-slate-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-kawa-500/50"
+                  />
+                  <button
+                    type="submit"
+                    disabled={!newWord.trim()}
+                    className="flex items-center gap-1 px-2.5 py-1 rounded-md text-sm font-medium bg-kawa-500 text-black hover:bg-kawa-400 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <Plus className="w-4 h-4" />
+                  </button>
+                </form>
+                {customWords.length === 0 ? (
+                  <p className="text-xs text-slate-400 dark:text-slate-500">
+                    No custom words yet. Words you add here are never flagged as misspelled.
+                  </p>
+                ) : (
+                  <div className="flex flex-wrap gap-1.5 max-h-40 overflow-y-auto">
+                    {customWords.map(w => (
+                      <span
+                        key={w}
+                        className="flex items-center gap-1 pl-2 pr-1 py-0.5 rounded bg-slate-100 dark:bg-neutral-700 text-xs font-mono text-slate-700 dark:text-slate-200"
+                      >
+                        {w}
+                        <button
+                          onClick={() => removeFromDictionary(w)}
+                          title={`Remove "${w}"`}
+                          className="text-slate-400 hover:text-red-500 transition-colors"
+                        >
+                          <X className="w-3 h-3" />
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
           </div>
         </div>
@@ -399,6 +501,14 @@ export function SpellCheckTool() {
             </div>
           ) : (
             <p className="text-[11px] italic text-slate-400 dark:text-slate-500">No automatic suggestion available.</p>
+          )}
+          {activeIssue.type === 'spelling' && (
+            <button
+              onClick={() => addToDictionary(activeIssue.text)}
+              className="w-full flex items-center justify-center gap-1 text-xs font-medium text-slate-500 hover:text-kawa-600 dark:text-slate-400 dark:hover:text-kawa-400 pt-1 transition-colors"
+            >
+              <BookPlus className="w-3.5 h-3.5" /> Add “{activeIssue.text}” to dictionary
+            </button>
           )}
           <button
             onClick={() => ignoreIssue(activeIssue)}

--- a/web/src/components/SpellCheckTool.tsx
+++ b/web/src/components/SpellCheckTool.tsx
@@ -106,6 +106,7 @@ export function SpellCheckTool() {
   const [dictOpen, setDictOpen] = useState(false);
   const [newWord, setNewWord] = useState('');
   const [refreshKey, setRefreshKey] = useState(0);
+  const [dictBusy, setDictBusy] = useState(false);
 
   const spanRefs = useRef<Record<string, HTMLSpanElement | null>>({});
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -200,22 +201,34 @@ export function SpellCheckTool() {
     setPopover(null);
   }, []);
 
-  const addToDictionary = useCallback(async (word: string) => {
+  const addToDictionary = useCallback(async (word: string): Promise<boolean> => {
     const w = word.trim();
-    if (!w) return;
+    if (!w || dictBusy) return false;
+    setDictBusy(true);
+    setError('');
     try {
       const resp = await client.addCustomWords({ words: [w] } as Parameters<typeof client.addCustomWords>[0]);
-      if (resp.error) { setError(resp.error); return; }
+      if (resp.error) { setError(resp.error); return false; }
       setCustomWords(resp.words);
-      setNewWord('');
       setPopover(null);
-      setRefreshKey(k => k + 1); // re-check so the word stops being flagged
+      // Drop matching spelling issues immediately for instant feedback; a full
+      // re-check follows via refreshKey.
+      const lw = w.toLowerCase();
+      setIssues(prev => prev.filter(is => !(is.type === 'spelling' && is.text.trim().toLowerCase() === lw)));
+      setRefreshKey(k => k + 1);
+      return true;
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to add word to dictionary');
+      return false;
+    } finally {
+      setDictBusy(false);
     }
-  }, []);
+  }, [dictBusy]);
 
   const removeFromDictionary = useCallback(async (word: string) => {
+    if (dictBusy) return;
+    setDictBusy(true);
+    setError('');
     try {
       const resp = await client.removeCustomWord({ word } as Parameters<typeof client.removeCustomWord>[0]);
       if (resp.error) { setError(resp.error); return; }
@@ -223,8 +236,10 @@ export function SpellCheckTool() {
       setRefreshKey(k => k + 1);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to remove word from dictionary');
+    } finally {
+      setDictBusy(false);
     }
-  }, []);
+  }, [dictBusy]);
 
   const focusIssue = useCallback((id: string) => {
     const el = spanRefs.current[id];
@@ -398,7 +413,8 @@ export function SpellCheckTool() {
                     {is.type === 'spelling' && (
                       <button
                         onClick={() => addToDictionary(is.text)}
-                        className="flex items-center gap-1 text-xs font-medium text-slate-400 hover:text-kawa-600 dark:hover:text-kawa-400 transition-colors"
+                        disabled={dictBusy}
+                        className="flex items-center gap-1 text-xs font-medium text-slate-400 hover:text-kawa-600 dark:hover:text-kawa-400 disabled:opacity-40 transition-colors"
                       >
                         <BookPlus className="w-3.5 h-3.5" /> Add to dictionary
                       </button>
@@ -413,6 +429,7 @@ export function SpellCheckTool() {
           <div className="bg-white dark:bg-neutral-800 rounded-lg border border-slate-200 dark:border-neutral-700 shadow-sm">
             <button
               onClick={() => setDictOpen(o => !o)}
+              aria-expanded={dictOpen}
               className="w-full flex items-center justify-between p-3 text-sm font-bold text-slate-600 dark:text-slate-300"
             >
               <span className="flex items-center gap-1.5">
@@ -424,18 +441,20 @@ export function SpellCheckTool() {
             {dictOpen && (
               <div className="p-3 pt-0 space-y-3">
                 <form
-                  onSubmit={e => { e.preventDefault(); addToDictionary(newWord); }}
+                  onSubmit={async e => { e.preventDefault(); if (await addToDictionary(newWord)) setNewWord(''); }}
                   className="flex gap-2"
                 >
                   <input
                     value={newWord}
                     onChange={e => setNewWord(e.target.value)}
                     placeholder="Add a word…"
+                    aria-label="Add a word to the custom dictionary"
                     className="flex-1 min-w-0 bg-slate-50 dark:bg-neutral-900 border border-slate-300 dark:border-neutral-700 rounded-md px-2 py-1 text-sm text-slate-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-kawa-500/50"
                   />
                   <button
                     type="submit"
-                    disabled={!newWord.trim()}
+                    disabled={!newWord.trim() || dictBusy}
+                    aria-label="Add word"
                     className="flex items-center gap-1 px-2.5 py-1 rounded-md text-sm font-medium bg-kawa-500 text-black hover:bg-kawa-400 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                   >
                     <Plus className="w-4 h-4" />
@@ -455,8 +474,9 @@ export function SpellCheckTool() {
                         {w}
                         <button
                           onClick={() => removeFromDictionary(w)}
+                          disabled={dictBusy}
                           title={`Remove "${w}"`}
-                          className="text-slate-400 hover:text-red-500 transition-colors"
+                          className="text-slate-400 hover:text-red-500 disabled:opacity-40 transition-colors"
                         >
                           <X className="w-3 h-3" />
                         </button>
@@ -505,7 +525,8 @@ export function SpellCheckTool() {
           {activeIssue.type === 'spelling' && (
             <button
               onClick={() => addToDictionary(activeIssue.text)}
-              className="w-full flex items-center justify-center gap-1 text-xs font-medium text-slate-500 hover:text-kawa-600 dark:text-slate-400 dark:hover:text-kawa-400 pt-1 transition-colors"
+              disabled={dictBusy}
+              className="w-full flex items-center justify-center gap-1 text-xs font-medium text-slate-500 hover:text-kawa-600 dark:text-slate-400 dark:hover:text-kawa-400 disabled:opacity-40 pt-1 transition-colors"
             >
               <BookPlus className="w-3.5 h-3.5" /> Add “{activeIssue.text}” to dictionary
             </button>

--- a/web/src/proto/proto/privutil.ts
+++ b/web/src/proto/proto/privutil.ts
@@ -1403,6 +1403,28 @@ export interface SpellLanguagesResponse {
   languages: SpellLanguage[];
 }
 
+/**
+ * Custom dictionary: a server-side, persisted list of extra accepted words,
+ * shared across all languages. SpellCheck consults it automatically.
+ */
+export interface GetCustomWordsRequest {
+}
+
+export interface AddCustomWordsRequest {
+  /** words to add (whitespace/case normalized server-side) */
+  words: string[];
+}
+
+export interface RemoveCustomWordRequest {
+  word: string;
+}
+
+export interface CustomWordsResponse {
+  /** the full custom word list after the operation, sorted */
+  words: string[];
+  error: string;
+}
+
 function createBaseDiffRequest(): DiffRequest {
   return { text1: "", text2: "" };
 }
@@ -16625,6 +16647,241 @@ export const SpellLanguagesResponse: MessageFns<SpellLanguagesResponse> = {
   },
 };
 
+function createBaseGetCustomWordsRequest(): GetCustomWordsRequest {
+  return {};
+}
+
+export const GetCustomWordsRequest: MessageFns<GetCustomWordsRequest> = {
+  encode(_: GetCustomWordsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetCustomWordsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetCustomWordsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): GetCustomWordsRequest {
+    return {};
+  },
+
+  toJSON(_: GetCustomWordsRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetCustomWordsRequest>, I>>(base?: I): GetCustomWordsRequest {
+    return GetCustomWordsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetCustomWordsRequest>, I>>(_: I): GetCustomWordsRequest {
+    const message = createBaseGetCustomWordsRequest();
+    return message;
+  },
+};
+
+function createBaseAddCustomWordsRequest(): AddCustomWordsRequest {
+  return { words: [] };
+}
+
+export const AddCustomWordsRequest: MessageFns<AddCustomWordsRequest> = {
+  encode(message: AddCustomWordsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.words) {
+      writer.uint32(10).string(v!);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AddCustomWordsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAddCustomWordsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.words.push(reader.string());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AddCustomWordsRequest {
+    return { words: globalThis.Array.isArray(object?.words) ? object.words.map((e: any) => globalThis.String(e)) : [] };
+  },
+
+  toJSON(message: AddCustomWordsRequest): unknown {
+    const obj: any = {};
+    if (message.words?.length) {
+      obj.words = message.words;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<AddCustomWordsRequest>, I>>(base?: I): AddCustomWordsRequest {
+    return AddCustomWordsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<AddCustomWordsRequest>, I>>(object: I): AddCustomWordsRequest {
+    const message = createBaseAddCustomWordsRequest();
+    message.words = object.words?.map((e) => e) || [];
+    return message;
+  },
+};
+
+function createBaseRemoveCustomWordRequest(): RemoveCustomWordRequest {
+  return { word: "" };
+}
+
+export const RemoveCustomWordRequest: MessageFns<RemoveCustomWordRequest> = {
+  encode(message: RemoveCustomWordRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.word !== "") {
+      writer.uint32(10).string(message.word);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RemoveCustomWordRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRemoveCustomWordRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.word = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RemoveCustomWordRequest {
+    return { word: isSet(object.word) ? globalThis.String(object.word) : "" };
+  },
+
+  toJSON(message: RemoveCustomWordRequest): unknown {
+    const obj: any = {};
+    if (message.word !== "") {
+      obj.word = message.word;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RemoveCustomWordRequest>, I>>(base?: I): RemoveCustomWordRequest {
+    return RemoveCustomWordRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RemoveCustomWordRequest>, I>>(object: I): RemoveCustomWordRequest {
+    const message = createBaseRemoveCustomWordRequest();
+    message.word = object.word ?? "";
+    return message;
+  },
+};
+
+function createBaseCustomWordsResponse(): CustomWordsResponse {
+  return { words: [], error: "" };
+}
+
+export const CustomWordsResponse: MessageFns<CustomWordsResponse> = {
+  encode(message: CustomWordsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.words) {
+      writer.uint32(10).string(v!);
+    }
+    if (message.error !== "") {
+      writer.uint32(18).string(message.error);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CustomWordsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCustomWordsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.words.push(reader.string());
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.error = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CustomWordsResponse {
+    return {
+      words: globalThis.Array.isArray(object?.words) ? object.words.map((e: any) => globalThis.String(e)) : [],
+      error: isSet(object.error) ? globalThis.String(object.error) : "",
+    };
+  },
+
+  toJSON(message: CustomWordsResponse): unknown {
+    const obj: any = {};
+    if (message.words?.length) {
+      obj.words = message.words;
+    }
+    if (message.error !== "") {
+      obj.error = message.error;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CustomWordsResponse>, I>>(base?: I): CustomWordsResponse {
+    return CustomWordsResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CustomWordsResponse>, I>>(object: I): CustomWordsResponse {
+    const message = createBaseCustomWordsResponse();
+    message.words = object.words?.map((e) => e) || [];
+    message.error = object.error ?? "";
+    return message;
+  },
+};
+
 export type PrivUtilServiceDefinition = typeof PrivUtilServiceDefinition;
 export const PrivUtilServiceDefinition = {
   name: "PrivUtilService",
@@ -17222,6 +17479,30 @@ export const PrivUtilServiceDefinition = {
       responseStream: false,
       options: {},
     },
+    getCustomWords: {
+      name: "GetCustomWords",
+      requestType: GetCustomWordsRequest as typeof GetCustomWordsRequest,
+      requestStream: false,
+      responseType: CustomWordsResponse as typeof CustomWordsResponse,
+      responseStream: false,
+      options: {},
+    },
+    addCustomWords: {
+      name: "AddCustomWords",
+      requestType: AddCustomWordsRequest as typeof AddCustomWordsRequest,
+      requestStream: false,
+      responseType: CustomWordsResponse as typeof CustomWordsResponse,
+      responseStream: false,
+      options: {},
+    },
+    removeCustomWord: {
+      name: "RemoveCustomWord",
+      requestType: RemoveCustomWordRequest as typeof RemoveCustomWordRequest,
+      requestStream: false,
+      responseType: CustomWordsResponse as typeof CustomWordsResponse,
+      responseStream: false,
+      options: {},
+    },
   },
 } as const;
 
@@ -17393,6 +17674,18 @@ export interface PrivUtilServiceImplementation<CallContextExt = {}> {
     request: SpellLanguagesRequest,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<SpellLanguagesResponse>>;
+  getCustomWords(
+    request: GetCustomWordsRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<CustomWordsResponse>>;
+  addCustomWords(
+    request: AddCustomWordsRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<CustomWordsResponse>>;
+  removeCustomWord(
+    request: RemoveCustomWordRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<CustomWordsResponse>>;
 }
 
 export interface PrivUtilServiceClient<CallOptionsExt = {}> {
@@ -17566,6 +17859,18 @@ export interface PrivUtilServiceClient<CallOptionsExt = {}> {
     request: DeepPartial<SpellLanguagesRequest>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<SpellLanguagesResponse>;
+  getCustomWords(
+    request: DeepPartial<GetCustomWordsRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<CustomWordsResponse>;
+  addCustomWords(
+    request: DeepPartial<AddCustomWordsRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<CustomWordsResponse>;
+  removeCustomWord(
+    request: DeepPartial<RemoveCustomWordRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<CustomWordsResponse>;
 }
 
 function bytesFromBase64(b64: string): Uint8Array {


### PR DESCRIPTION
Adds a custom dictionary so users can mark words that should never be flagged as misspelled. Server-side (per your choice), one shared list across languages, persisted to a file. Reviewed by a four-agent pass; all findings fixed in the second commit.

## Feature (`ca4dd4d`)
- **Engine**: `spellcheck.CheckWithCustom` consults an optional `Lookup` in addition to the built-in dictionary; a matched word is skipped (grammar checks unaffected).
- **Persistence**: `customDict` — thread-safe, file-backed word set (atomic temp+rename, case-insensitive, caps 10k words / 64 chars, in-memory when no path).
- **RPCs**: `GetCustomWords` / `AddCustomWords` / `RemoveCustomWord`; `SpellCheck` consults the dictionary automatically. `Server` gains functional options (`WithCustomDictPath`); `NewServer()` unchanged.
- **CLI**: `-custom-dict` / `CUSTOM_DICT`, defaulting to `os.UserConfigDir()/privutil/custom-dictionary.txt`. Docker persists under `/data` via a mounted named volume.
- **UI**: "Add to dictionary" on spelling issues (card + popover) and a custom-dictionary manager (add/list/remove).

## Review fixes (`cb7ab58`)
- Backend: `Add`/`Remove` made **transactional** (validate + cap-check before mutating, roll back on persist failure); **reject control-character words** (ANSI-escape injection into the file); `fsync` before rename; skip no-op rewrites.
- Infra: dropped `VOLUME /data` (anonymous-volume data-loss/orphan footgun); documented named-volume + bind-mount chown.
- Frontend: in-flight guard against double-submit / out-of-order responses; instant un-flagging on add; clear input only on successful submit; `aria-label`/`aria-expanded`.

## Verification
`make lint` + `make test` green (backend incl. transactional + control-char tests, 58 frontend). Runtime confirmed: add→persist→no-longer-flagged→list/remove, transactional rejection (nothing persisted on a failing batch), Host-allowlist + CSP intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)