### PR TITLE
docs: refresh top-level docs (+ wiki) for current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ make test-coverage  # HTML coverage reports
 go test -v -run TestFunctionName ./internal/api/
 
 # Single frontend test
-cd web && npm test -- --grep "pattern"
+cd web && npm test -- -t "pattern"
 
 # Lint
 make lint           # all linters
@@ -38,22 +38,22 @@ PrivUtil is a full-stack Go + React app served as a single self-contained binary
 
 **Request flow:**
 ```
-Browser (React + nice-grpc-web) → HTTP server (gRPC-Web wrapper) → gRPC handlers → Go business logic
+Browser (React + nice-grpc-web) → HTTP server (connect-go handler over h2c) → connect handlers → Go business logic
 ```
 
 **Key layers:**
-- `cmd/privutil/main.go` — CLI flags, initializes gRPC server and HTTP server
-- `internal/server/server.go` — HTTP server that wraps gRPC-Web, serves embedded React assets with SPA fallback
-- `internal/api/grpc_server.go` — registers all gRPC service implementations
-- `internal/api/*_handlers.go` — domain-grouped handler files: `data_handlers.go`, `text_handlers.go`, `encoding_handlers.go`, `gen_handlers.go`, `security_handlers.go`, `system_handlers.go`
-- `proto/privutil.proto` — single proto file defining all ~29 RPC methods; generated Go code is committed
+- `cmd/privutil/main.go` — CLI flags, initializes the connect service handler and HTTP server
+- `internal/server/server.go` — HTTP server serving the connect handler over h2c, with a Host-header allowlist, allowlist-scoped CORS, and CSP/security-header middleware; serves embedded React assets with SPA fallback
+- `internal/api/server.go` — the `Server` type and `NewServer` (functional options); `internal/api/connect_adapter.go` — adapts `*Server` to the generated connect handler interface (`NewConnectServer`)
+- `internal/api/*_handlers.go` — domain-grouped handler files: `data_handlers.go`, `text_handlers.go`, `encoding_handlers.go`, `gen_handlers.go`, `security_handlers.go`, `crypto_handlers.go`, `datetime_handlers.go`, `math_handlers.go`, `media_handlers.go`, `network_handlers.go`, `spell_handlers.go`, `text_tools_handlers.go`, `token_handlers.go`, `webdevops_handlers.go`, `system_handlers.go`
+- `proto/privutil.proto` — single proto file defining all 77 RPC methods; generated Go code (`proto/privutil.pb.go`, `proto/protoconnect/privutil.connect.go`) is committed
 - `web/src/` — React frontend; `web/src/proto/` contains generated TypeScript proto bindings (also committed)
 
 ## Adding a New Tool
 
 1. Add the RPC method and request/response messages to `proto/privutil.proto`
-2. Run `make proto` to regenerate `proto/privutil.pb.go`, `proto/privutil_grpc.pb.go`, and `web/src/proto/`
-3. Implement the handler in the appropriate `internal/api/*_handlers.go` file and register it in `grpc_server.go`
+2. Run `make proto` to regenerate `proto/privutil.pb.go`, `proto/protoconnect/privutil.connect.go`, and `web/src/proto/`
+3. Implement the handler in the appropriate `internal/api/*_handlers.go` file and add the matching adapter method in `internal/api/connect_adapter.go`
 4. Add the React component under `web/src/components/` and wire it into the router in `web/src/App.tsx`
 
 See `wiki/Adding-New-Features.md` for a detailed walkthrough.
@@ -65,8 +65,10 @@ The server accepts flags and environment variables:
 | Flag | Env | Default |
 |------|-----|---------|
 | `-port` | `PORT` | `8090` |
-| `-host` | `HOST` | `localhost` |
-| `-log-level` | `LOG_LEVEL` | `info` |
+| `-host` | `HOST` | `127.0.0.1` (loopback; use `0.0.0.0` for all interfaces) |
+| `-allowed-hosts` | `ALLOWED_HOSTS` | (empty) — extra allowed `Host` header values, comma-separated |
+| `-custom-dict` | `CUSTOM_DICT` | `<user-config-dir>/privutil/custom-dictionary.txt` |
+| `-log-level` | `LOG_LEVEL` | `info` (`debug` or `info` only) |
 
 ## Commit Convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ to our team.
 
 ## I Have a Question
 
-If you want to ask a question, we assume that you have read the available [Documentation](link-to-docs).
+If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/odinnordico/privutil/wiki).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/odinnordico/privutil/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
@@ -42,12 +42,12 @@ We will then take care of the issue as soon as possible.
 
 ### Reporting Bugs
 
-**If you find a security vulnerability, please send an email to security@example.com instead of using the issue tracker.**
+**If you find a security vulnerability, do not use the issue tracker — report it privately following [SECURITY.md](SECURITY.md).**
 
 Before you submit a bug report, please check these points:
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](link-to-docs). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/odinnordico/privutil/wiki). If you are looking for support, you might want to check [this section](#i-have-a-question)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/odinnordico/privutil/issues?q=label%3Abug).
 
 ### Suggesting Enhancements

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project was "developed" with Antigravity AI. I am the owner of the project 
 | **Diff Utility** | Visual text comparison with syntax highlighting |
 | **Text Tools** | Sort, dedupe, reverse, trim, inspect line count/word count/bytes |
 | **Text Similarity** | Levenshtein distance and similarity percentage |
-| **Spell & Grammar Checker** | Fully offline spelling and grammar/punctuation checking; English and Latin American Spanish; embedded ~50k-word dictionaries; inline wavy underlines with one-click fixes |
+| **Spell & Grammar Checker** | Fully offline spelling and grammar/punctuation checking; English and Latin American Spanish; embedded ~50k-word dictionaries; inline wavy underlines with one-click fixes; add words to a persistent custom dictionary (never flagged again) |
 | **Token Counter** | Offline LLM token counter; exact BPE for OpenAI (o200k_base/cl100k_base), heuristic estimates for Claude/Llama 3/Gemini/Mistral, plus classic tokenizers; char/byte counts, token preview, side-by-side comparison |
 
 ### Formatters & Converters
@@ -56,7 +56,7 @@ This project was "developed" with Antigravity AI. I am the owner of the project 
 
 | Tool | Description |
 | ---- | ----------- |
-| **Base64** | Encode/decode strings |
+| **Base64** | Encode text or uploaded files; decode raw or data-URI input with MIME-aware inline preview (text, images, PDF, audio, video, and binary/gRPC payloads as text up to 5 MB) |
 | **URL Encoder/Decoder** | Percent-encoding |
 | **HTML Entity Encoder/Decoder** | Named and numeric entities |
 | **HMAC Generator** | SHA-256/SHA-512/SHA-1/MD5 with hex and base64 output |
@@ -215,13 +215,17 @@ Access at **http://localhost:8090**
 ./privutil --help
 
 Options:
-  -port string      Port to listen on (default "8090")
-  -host string      Host to bind to (default "localhost")
-  -log-level string Log level: debug, info, warn, error (default "info")
-  -version          Print version and exit
+  -port string          Port to listen on (default "8090")
+  -host string          Host to bind to (default "127.0.0.1"; use 0.0.0.0 for all interfaces)
+  -allowed-hosts string Comma-separated extra Host header values to accept (for LAN/custom-domain access)
+  -custom-dict string   Path to the spellchecker custom-dictionary file (default: <user-config-dir>/privutil/custom-dictionary.txt)
+  -log-level string     Log level: debug or info (default "info")
+  -version              Print version and exit
 ```
 
-Environment variables: `PORT`, `HOST`, `LOG_LEVEL`
+Environment variables: `PORT`, `HOST`, `ALLOWED_HOSTS`, `CUSTOM_DICT`, `LOG_LEVEL`
+
+> The server binds to loopback (`127.0.0.1`) by default and only accepts requests whose `Host` header is `localhost`/`127.0.0.1`/`::1` (a DNS-rebinding defense). To expose it on a LAN, set `-host 0.0.0.0` **and** add the reachable host name(s) to `ALLOWED_HOSTS`.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,23 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Security fixes are released against the latest published version. Please upgrade
+to the newest release before reporting.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| latest  | :white_check_mark: |
+| older   | :x:                |
+
+## Security Posture
+
+PrivUtil is a local-first tool and hardens accordingly:
+
+- Binds to loopback (`127.0.0.1`) by default; exposing it requires an explicit `-host 0.0.0.0`.
+- Validates the `Host` header against an allowlist (DNS-rebinding defense) and scopes CORS to allowlisted origins (no wildcard).
+- Serves a Content-Security-Policy plus `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy`.
+- Caps request bodies (32 MiB) and bounds compute-heavy handlers (e.g. bcrypt cost ≤ 15, MathEval/BaseConvert/TextSimilarity input limits); recovers from handler panics.
+- Release container images are multi-arch, cosign keyless-signed, and ship an SBOM and SLSA provenance.
 
 ## Reporting a Vulnerability
 
@@ -16,9 +26,11 @@ We take the security of PrivUtil seriously. If you have discovered a security vu
 
 ### How to Report
 
-Please send an email to **[INSERT EMAIL HERE]**.
+Preferred: open a private [GitHub security advisory](https://github.com/odinnordico/PrivUtil/security/advisories/new) for this repository.
 
-You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+<!-- TODO: add a dedicated security contact email address here. -->
+
+You should receive a response within 48 hours. If for some reason you do not, please follow up to ensure we received your original message.
 
 ### Process
 


### PR DESCRIPTION
Documentation review driven by four scoped review agents (setup/config/deploy, API/architecture/features, tools pages, top-level/security), each verifying claims against the real code. Fixes span the main repo and the wiki submodule.

## Main repo (this PR)
- **CLAUDE.md**: 77 RPCs (not "~29"); connect-go transport; drop the removed `grpc_server.go` / `privutil_grpc.pb.go`; correct handler + generated-file list; config table (HOST=127.0.0.1, add `ALLOWED_HOSTS`/`CUSTOM_DICT`, log levels); single-frontend-test command `-t`.
- **README.md**: `-host` default `127.0.0.1`; add `-allowed-hosts`/`-custom-dict` + env vars + Host-allowlist note; mention spellcheck custom dictionary and base64 inline preview.
- **SECURITY.md**: replace boilerplate versions + placeholder email (GitHub advisory + a `TODO` for a contact email — left per request); document actual security posture.
- **CONTRIBUTING.md**: security reports → SECURITY.md; fix dead doc links.
- Bumps the **wiki submodule** pointer to the refreshed wiki.

## Wiki (already pushed to `privutil.wiki.git`)
13 pages updated: Configuration, Quick-Start, Installation, Building, Deployment, API-Reference, Architecture, Adding-New-Features, Features-Overview, Tools-Security, Tools-Text-Diff, Tools-Generators, Tools-Formatters.

Highlights: HOST/loopback + allowlist + new flags; `make build` (not bare `go build`) and CGO-free note; ghcr image + `/data` named volume + cosign verify + fixed custom Dockerfile; k8s image/env/PVC; **reverse-proxy Host-allowlist gotcha**; connect-go (77 RPCs) + 3 custom-dict RPCs, real dir layout/request-flow, drop `grpcweb.WrapServer`; base64 inline preview; spellcheck custom dictionary; plus pre-existing bugs (cert fields, HTML entity `&#39;`, UUID v1–v8+namespaces, missing RSA Keys generator, bcrypt cost, diff "side-by-side"→inline, color HSL output-only).

> Note: the wiki is a live GitHub wiki (separate repo) and these changes are already published; this PR only carries the main-repo docs + the submodule pointer bump. One `TODO` remains in SECURITY.md/implicitly for a dedicated security-contact email, left intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)